### PR TITLE
feat: Implementa Tema Escuro (RNF-01.3)

### DIFF
--- a/AgendaFocoPEI/app/build.gradle
+++ b/AgendaFocoPEI/app/build.gradle
@@ -53,7 +53,11 @@ dependencies {
     implementation "com.github.kizitonwose:calendarview:2.5.1"
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation "androidx.arch.core:core-testing:2.2.0" // Para InstantTaskExecutorRule
+    testImplementation "org.mockito:mockito-core:5.11.0"       // Para mock SharedPreferences
+    testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3" // Para testes de corrotinas
+
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation "androidx.room:room-testing:$room_version" // Adicionado Room Testing
+    androidTestImplementation "androidx.room:room-testing:$room_version"
 }

--- a/AgendaFocoPEI/app/src/main/AndroidManifest.xml
+++ b/AgendaFocoPEI/app/src/main/AndroidManifest.xml
@@ -3,6 +3,14 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.agendafocopei">
 
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -46,7 +54,34 @@
             android:name=".ui.activity.AgendaActivity"
             android:label="Agenda"
             android:parentActivityName=".DashboardActivity" />
-            <!-- Ou .MainActivity se preferir que volte direto para a tela principal -->
+        <activity
+            android:name=".ui.activity.PlanosDeAulaGeralActivity"
+            android:label="Planos de Aula"
+            android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".ui.activity.GuiasDeAprendizagemActivity"
+            android:label="Guias de Aprendizagem"
+            android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".ui.activity.DetalhesGuiaActivity"
+            android:label="Detalhes do Guia"
+            android:parentActivityName=".ui.activity.GuiasDeAprendizagemActivity" />
+        <activity
+            android:name=".ui.activity.TemplatesPlanoAulaActivity"
+            android:label="Templates de Plano de Aula"
+            android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".ui.activity.TarefasActivity"
+            android:label="Minhas Tarefas"
+            android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".ui.activity.PomodoroActivity"
+            android:label="Pomodoro"
+            android:parentActivityName=".DashboardActivity" />
+        <activity
+            android:name=".ui.activity.AnotacoesActivity"
+            android:label="Minhas Anotações"
+            android:parentActivityName=".MainActivity" />
     </application>
 
 </manifest>

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/Anotacao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/Anotacao.kt
@@ -1,0 +1,28 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+
+@Entity(
+    tableName = "anotacoes",
+    foreignKeys = [
+        ForeignKey(
+            entity = Turma::class,
+            parentColumns = ["id"],
+            childColumns = ["turmaId"],
+            onDelete = ForeignKey.SET_NULL // Se a Turma for deletada, turmaId se torna NULL
+        )
+    ],
+    indices = [Index(value = ["turmaId"])]
+)
+data class Anotacao(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(typeAffinity = ColumnInfo.TEXT) var conteudo: String,
+    @ColumnInfo(name = "data_criacao", defaultValue = "0") // DefaultValue para Room
+    val dataCriacao: Long = System.currentTimeMillis(),
+    @ColumnInfo(name = "data_modificacao", defaultValue = "0") // DefaultValue para Room
+    var dataModificacao: Long = System.currentTimeMillis(),
+    var cor: Int? = null, // ARGB Int color
+    var turmaId: Int?,
+    @ColumnInfo(name = "aluno_nome") var alunoNome: String? = null,
+    @ColumnInfo(name = "tags_string") var tagsString: String? = null // Ex: "#ideia #importante #reuniao"
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/AnotacaoDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/AnotacaoDao.kt
@@ -1,0 +1,38 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface AnotacaoDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserir(anotacao: Anotacao): Long
+
+    @Update
+    suspend fun atualizar(anotacao: Anotacao)
+
+    @Delete
+    suspend fun deletar(anotacao: Anotacao)
+
+    @Query("DELETE FROM anotacoes WHERE id = :id")
+    suspend fun deleteById(id: Int)
+
+    @Query("SELECT * FROM anotacoes WHERE id = :id")
+    suspend fun buscarPorId(id: Int): Anotacao?
+
+    @Query("SELECT * FROM anotacoes ORDER BY data_modificacao DESC")
+    fun buscarTodas(): Flow<List<Anotacao>>
+
+    @Query("SELECT * FROM anotacoes WHERE turmaId = :turmaId ORDER BY data_modificacao DESC")
+    fun buscarPorTurmaId(turmaId: Int): Flow<List<Anotacao>>
+
+    // Query para buscar por tags (simples, usando LIKE)
+    // Adicionar % antes e depois do termoTag para buscar em qualquer parte da string
+    // Ex: Para buscar #ideia, termoTag seria "%#ideia%"
+    @Query("SELECT * FROM anotacoes WHERE tags_string LIKE :termoTag ORDER BY data_modificacao DESC")
+    fun buscarPorTag(termoTag: String): Flow<List<Anotacao>>
+
+    // Query para buscar por conteúdo (usando FTS se configurado, ou LIKE para simples)
+    @Query("SELECT * FROM anotacoes WHERE conteudo LIKE :textoConteudo ORDER BY data_modificacao DESC")
+    fun buscarPorConteudo(textoConteudo: String): Flow<List<Anotacao>>
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/AppDatabase.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/AppDatabase.kt
@@ -13,9 +13,16 @@ import androidx.sqlite.db.SupportSQLiteDatabase
         Turma::class,
         DisciplinaTurmaCrossRef::class,
         HorarioAula::class,
-            Evento::class // <<< ATUALIZADO para Evento
+        Evento::class,
+        PlanoDeAula::class,
+        GuiaDeAprendizagem::class,
+        ItemChecklistGuia::class,
+        TemplatePlanoAula::class,
+        Tarefa::class,
+        Subtarefa::class,
+        Anotacao::class // <<< ADICIONADO Anotacao
     ],
-        version = 6, // <<< INCREMENTADO PARA 6
+    version = 10, // <<< INCREMENTADO PARA 10
     exportSchema = false
 )
 abstract class AppDatabase : RoomDatabase() {
@@ -24,23 +31,24 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun turmaDao(): TurmaDao
     abstract fun disciplinaTurmaDao(): DisciplinaTurmaDao
     abstract fun horarioAulaDao(): HorarioAulaDao
-    abstract fun eventoDao(): EventoDao // <<< DAO RENOMEADO
+    abstract fun eventoDao(): EventoDao
+    abstract fun planoDeAulaDao(): PlanoDeAulaDao
+    abstract fun guiaDeAprendizagemDao(): GuiaDeAprendizagemDao
+    abstract fun itemChecklistGuiaDao(): ItemChecklistGuiaDao
+    abstract fun templatePlanoAulaDao(): TemplatePlanoAulaDao
+    abstract fun tarefaDao(): TarefaDao
+    abstract fun subtarefaDao(): SubtarefaDao
+    abstract fun anotacaoDao(): AnotacaoDao // <<< NOVO DAO
+
 
     companion object {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        // ... (Migrações MIGRATION_1_2 até MIGRATION_8_9 permanecem as mesmas) ...
         val MIGRATION_1_2 = object : Migration(1, 2) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("""
-                    CREATE TABLE IF NOT EXISTS `disciplina_turma_cross_ref` (
-                        `disciplinaId` INTEGER NOT NULL,
-                        `turmaId` INTEGER NOT NULL,
-                        PRIMARY KEY(`disciplinaId`, `turmaId`),
-                        FOREIGN KEY(`disciplinaId`) REFERENCES `disciplinas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-                        FOREIGN KEY(`turmaId`) REFERENCES `turmas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-                    )
-                """)
+                database.execSQL("CREATE TABLE IF NOT EXISTS `disciplina_turma_cross_ref` (`disciplinaId` INTEGER NOT NULL, `turmaId` INTEGER NOT NULL, PRIMARY KEY(`disciplinaId`, `turmaId`), FOREIGN KEY(`disciplinaId`) REFERENCES `disciplinas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE, FOREIGN KEY(`turmaId`) REFERENCES `turmas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
                 database.execSQL("CREATE INDEX IF NOT EXISTS `index_disciplina_turma_cross_ref_disciplinaId` ON `disciplina_turma_cross_ref` (`disciplinaId`)")
                 database.execSQL("CREATE INDEX IF NOT EXISTS `index_disciplina_turma_cross_ref_turmaId` ON `disciplina_turma_cross_ref` (`turmaId`)")
             }
@@ -53,50 +61,70 @@ abstract class AppDatabase : RoomDatabase() {
         }
         val MIGRATION_3_4 = object : Migration(3, 4) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("""
-                    CREATE TABLE IF NOT EXISTS `horarios_aula` (
-                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                        `dia_da_semana` INTEGER NOT NULL,
-                        `hora_inicio` TEXT NOT NULL,
-                        `hora_fim` TEXT NOT NULL,
-                        `disciplinaId` INTEGER NOT NULL,
-                        `turmaId` INTEGER NOT NULL,
-                        `sala_aula` TEXT,
-                        FOREIGN KEY(`disciplinaId`) REFERENCES `disciplinas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE,
-                        FOREIGN KEY(`turmaId`) REFERENCES `turmas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
-                    )
-                """)
+                database.execSQL("CREATE TABLE IF NOT EXISTS `horarios_aula` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `dia_da_semana` INTEGER NOT NULL, `hora_inicio` TEXT NOT NULL, `hora_fim` TEXT NOT NULL, `disciplinaId` INTEGER NOT NULL, `turmaId` INTEGER NOT NULL, `sala_aula` TEXT, FOREIGN KEY(`disciplinaId`) REFERENCES `disciplinas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE, FOREIGN KEY(`turmaId`) REFERENCES `turmas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
                 database.execSQL("CREATE INDEX IF NOT EXISTS `index_horarios_aula_disciplinaId` ON `horarios_aula` (`disciplinaId`)")
                 database.execSQL("CREATE INDEX IF NOT EXISTS `index_horarios_aula_turmaId` ON `horarios_aula` (`turmaId`)")
             }
         }
-
-        // NOVA MIGRAÇÃO DE 4 PARA 5
         val MIGRATION_4_5 = object : Migration(4, 5) {
             override fun migrate(database: SupportSQLiteDatabase) {
-                database.execSQL("""
-                    CREATE TABLE IF NOT EXISTS `eventos_recorrentes` (
-                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                        `nome_evento` TEXT NOT NULL,
-                        `dia_da_semana` INTEGER NOT NULL,
-                        `hora_inicio` TEXT NOT NULL,
-                        `hora_fim` TEXT NOT NULL,
-                        `sala_local` TEXT,
-                        `cor` INTEGER,
-                        `observacoes` TEXT
-                    )
-                """)
+                database.execSQL("CREATE TABLE IF NOT EXISTS `eventos_recorrentes` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nome_evento` TEXT NOT NULL, `dia_da_semana` INTEGER NOT NULL, `hora_inicio` TEXT NOT NULL, `hora_fim` TEXT NOT NULL, `sala_local` TEXT, `cor` INTEGER, `observacoes` TEXT)")
+            }
+        }
+        val MIGRATION_5_6 = object : Migration(5, 6) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("ALTER TABLE eventos_recorrentes ADD COLUMN data_especifica TEXT DEFAULT NULL")
+            }
+        }
+        val MIGRATION_6_7 = object : Migration(6, 7) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `planos_de_aula` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `horarioAulaId` INTEGER, `data_aula` TEXT, `disciplinaId` INTEGER NOT NULL, `turmaId` INTEGER, `titulo_plano` TEXT, `texto_plano` TEXT, `caminho_anexo` TEXT, `tipo_anexo` TEXT, `template_usado_id` INTEGER, FOREIGN KEY(`horarioAulaId`) REFERENCES `horarios_aula`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL, FOREIGN KEY(`disciplinaId`) REFERENCES `disciplinas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE, FOREIGN KEY(`turmaId`) REFERENCES `turmas`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_planos_de_aula_horarioAulaId` ON `planos_de_aula` (`horarioAulaId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_planos_de_aula_disciplinaId` ON `planos_de_aula` (`disciplinaId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_planos_de_aula_turmaId` ON `planos_de_aula` (`turmaId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_planos_de_aula_template_usado_id` ON `planos_de_aula` (`template_usado_id`)")
+                database.execSQL("CREATE TABLE IF NOT EXISTS `guias_de_aprendizagem` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `bimestre` TEXT NOT NULL, `ano` INTEGER NOT NULL, `disciplinaId` INTEGER NOT NULL, `caminho_anexo_guia` TEXT, `tipo_anexo_guia` TEXT, `titulo_guia` TEXT, FOREIGN KEY(`disciplinaId`) REFERENCES `disciplinas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_guias_de_aprendizagem_disciplinaId` ON `guias_de_aprendizagem` (`disciplinaId`)")
+                database.execSQL("CREATE TABLE IF NOT EXISTS `itens_checklist_guia` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `guiaAprendizagemId` INTEGER NOT NULL, `descricao_item` TEXT NOT NULL, `concluido` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`guiaAprendizagemId`) REFERENCES `guias_de_aprendizagem`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_itens_checklist_guia_guiaAprendizagemId` ON `itens_checklist_guia` (`guiaAprendizagemId`)")
+                database.execSQL("CREATE TABLE IF NOT EXISTS `templates_plano_aula` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `nome_template` TEXT NOT NULL, `campo_habilidades` TEXT, `campo_recursos` TEXT, `campo_metodologia` TEXT, `campo_avaliacao` TEXT, `outros_campos` TEXT)")
+            }
+        }
+        val MIGRATION_7_8 = object : Migration(7, 8) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `tarefas` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `descricao` TEXT NOT NULL, `prazo_data` TEXT, `prazo_hora` TEXT, `prioridade` INTEGER NOT NULL, `disciplinaId` INTEGER, `turmaId` INTEGER, `concluida` INTEGER NOT NULL DEFAULT 0, `data_criacao` INTEGER NOT NULL DEFAULT 0, `data_conclusao` INTEGER, `lembrete_configurado` INTEGER NOT NULL DEFAULT 0, `lembrete_datetime` INTEGER, FOREIGN KEY(`disciplinaId`) REFERENCES `disciplinas`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL, FOREIGN KEY(`turmaId`) REFERENCES `turmas`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_tarefas_disciplinaId` ON `tarefas` (`disciplinaId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_tarefas_turmaId` ON `tarefas` (`turmaId`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_tarefas_prazo_data` ON `tarefas` (`prazo_data`)")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_tarefas_concluida` ON `tarefas` (`concluida`)")
+            }
+        }
+        val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("CREATE TABLE IF NOT EXISTS `subtarefas` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `tarefaId` INTEGER NOT NULL, `descricao_subtarefa` TEXT NOT NULL, `concluida` INTEGER NOT NULL DEFAULT 0, `ordem` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`tarefaId`) REFERENCES `tarefas`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )")
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_subtarefas_tarefaId` ON `subtarefas` (`tarefaId`)")
             }
         }
 
-            // NOVA MIGRAÇÃO DE 5 PARA 6
-            val MIGRATION_5_6 = object : Migration(5, 6) {
-                override fun migrate(database: SupportSQLiteDatabase) {
-                    // Adiciona a nova coluna 'data_especifica' à tabela 'eventos_recorrentes'
-                    // Mantendo o nome da tabela como 'eventos_recorrentes' por simplicidade nesta migração.
-                    database.execSQL("ALTER TABLE eventos_recorrentes ADD COLUMN data_especifica TEXT DEFAULT NULL")
-                }
+        // NOVA MIGRAÇÃO DE 9 PARA 10
+        val MIGRATION_9_10 = object : Migration(9, 10) {
+            override fun migrate(database: SupportSQLiteDatabase) {
+                database.execSQL("""
+                    CREATE TABLE IF NOT EXISTS `anotacoes` (
+                        `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                        `conteudo` TEXT NOT NULL,
+                        `data_criacao` INTEGER NOT NULL DEFAULT 0,
+                        `data_modificacao` INTEGER NOT NULL DEFAULT 0,
+                        `cor` INTEGER,
+                        `turmaId` INTEGER,
+                        `aluno_nome` TEXT,
+                        `tags_string` TEXT,
+                        FOREIGN KEY(`turmaId`) REFERENCES `turmas`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+                    )
+                """)
+                database.execSQL("CREATE INDEX IF NOT EXISTS `index_anotacoes_turmaId` ON `anotacoes` (`turmaId`)")
             }
+        }
 
         fun getDatabase(context: Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
@@ -105,7 +133,17 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "agenda_foco_pei_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, MIGRATION_4_5, MIGRATION_5_6) // <<< ADICIONAR NOVA MIGRAÇÃO
+                .addMigrations(
+                    MIGRATION_1_2,
+                    MIGRATION_2_3,
+                    MIGRATION_3_4,
+                    MIGRATION_4_5,
+                    MIGRATION_5_6,
+                    MIGRATION_6_7,
+                    MIGRATION_7_8,
+                    MIGRATION_8_9,
+                    MIGRATION_9_10 // <<< ADICIONAR NOVA MIGRAÇÃO
+                )
                 .build()
                 INSTANCE = instance
                 instance

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/GuiaDeAprendizagem.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/GuiaDeAprendizagem.kt
@@ -1,0 +1,25 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+
+@Entity(
+    tableName = "guias_de_aprendizagem",
+    foreignKeys = [
+        ForeignKey(
+            entity = Disciplina::class,
+            parentColumns = ["id"],
+            childColumns = ["disciplinaId"],
+            onDelete = ForeignKey.CASCADE // Se a Disciplina for deletada, os Guias associados são deletados.
+        )
+    ],
+    indices = [Index(value = ["disciplinaId"])]
+)
+data class GuiaDeAprendizagem(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val bimestre: String, // Ex: "1º Bimestre", "2º Bimestre", etc.
+    val ano: Int,
+    val disciplinaId: Int,
+    @ColumnInfo(name = "caminho_anexo_guia") val caminhoAnexoGuia: String?, // URI como String
+    @ColumnInfo(name = "tipo_anexo_guia") val tipoAnexoGuia: String?, // Ex: "application/pdf"
+    @ColumnInfo(name = "titulo_guia") val tituloGuia: String? = null // Título opcional para o guia
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/GuiaDeAprendizagemDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/GuiaDeAprendizagemDao.kt
@@ -1,0 +1,46 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface GuiaDeAprendizagemDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserir(guia: GuiaDeAprendizagem): Long
+
+    @Update
+    suspend fun atualizar(guia: GuiaDeAprendizagem)
+
+    @Delete
+    suspend fun deletar(guia: GuiaDeAprendizagem)
+
+    @Query("SELECT * FROM guias_de_aprendizagem WHERE id = :id")
+    suspend fun buscarPorId(id: Int): GuiaDeAprendizagem?
+
+    @Query("SELECT * FROM guias_de_aprendizagem ORDER BY ano DESC, bimestre DESC")
+    fun buscarTodos(): Flow<List<GuiaDeAprendizagem>>
+
+    @Query("SELECT * FROM guias_de_aprendizagem WHERE disciplinaId = :disciplinaId ORDER BY ano DESC, bimestre DESC")
+    fun buscarPorDisciplina(disciplinaId: Int): Flow<List<GuiaDeAprendizagem>>
+
+    @Query("SELECT * FROM guias_de_aprendizagem WHERE ano = :ano ORDER BY bimestre DESC")
+    fun buscarPorAno(ano: Int): Flow<List<GuiaDeAprendizagem>>
+
+    @Transaction
+    @Query("""
+        SELECT g.*, d.nome_disciplina AS nome_disciplina, d.cor AS cor_disciplina
+        FROM guias_de_aprendizagem g
+        INNER JOIN disciplinas d ON g.disciplinaId = d.id
+        ORDER BY g.ano DESC, g.bimestre DESC
+    """)
+    fun buscarTodosParaDisplay(): Flow<List<com.agendafocopei.ui.model.GuiaDeAprendizagemDisplay>>
+
+    @Transaction
+    @Query("""
+        SELECT g.*, d.nome_disciplina AS nome_disciplina, d.cor AS cor_disciplina
+        FROM guias_de_aprendizagem g
+        INNER JOIN disciplinas d ON g.disciplinaId = d.id
+        WHERE g.id = :guiaId
+    """)
+    suspend fun buscarDisplayPorId(guiaId: Int): com.agendafocopei.ui.model.GuiaDeAprendizagemDisplay?
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/HorarioAulaDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/HorarioAulaDao.kt
@@ -45,8 +45,10 @@ interface HorarioAulaDao {
             h.hora_fim AS horaFim,
             d.nome_disciplina AS nomeDisciplina,
             d.cor AS corDisciplina,
+            h.disciplinaId AS disciplinaId,
             t.nome_turma AS nomeTurma,
             t.cor AS corTurma,
+            h.turmaId AS turmaId,
             h.sala_aula AS salaAula
         FROM horarios_aula h
         INNER JOIN disciplinas d ON h.disciplinaId = d.id
@@ -64,8 +66,10 @@ interface HorarioAulaDao {
             h.hora_fim AS horaFim,
             d.nome_disciplina AS nomeDisciplina,
             d.cor AS corDisciplina,
+            h.disciplinaId AS disciplinaId,
             t.nome_turma AS nomeTurma,
             t.cor AS corTurma,
+            h.turmaId AS turmaId,
             h.sala_aula AS salaAula
         FROM horarios_aula h
         INNER JOIN disciplinas d ON h.disciplinaId = d.id
@@ -85,8 +89,10 @@ interface HorarioAulaDao {
             h.hora_fim AS horaFim,
             d.nome_disciplina AS nomeDisciplina,
             d.cor AS corDisciplina,
+            h.disciplinaId AS disciplinaId,
             t.nome_turma AS nomeTurma,
             t.cor AS corTurma,
+            h.turmaId AS turmaId,
             h.sala_aula AS salaAula
         FROM horarios_aula h
         INNER JOIN disciplinas d ON h.disciplinaId = d.id

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/ItemChecklistGuia.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/ItemChecklistGuia.kt
@@ -1,0 +1,22 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+
+@Entity(
+    tableName = "itens_checklist_guia",
+    foreignKeys = [
+        ForeignKey(
+            entity = GuiaDeAprendizagem::class,
+            parentColumns = ["id"],
+            childColumns = ["guiaAprendizagemId"],
+            onDelete = ForeignKey.CASCADE // Se o Guia for deletado, seus itens de checklist são deletados.
+        )
+    ],
+    indices = [Index(value = ["guiaAprendizagemId"])]
+)
+data class ItemChecklistGuia(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val guiaAprendizagemId: Int,
+    @ColumnInfo(name = "descricao_item") val descricaoItem: String,
+    var concluido: Boolean = false
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/ItemChecklistGuiaDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/ItemChecklistGuiaDao.kt
@@ -1,0 +1,32 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ItemChecklistGuiaDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserir(item: ItemChecklistGuia): Long
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserirVarios(itens: List<ItemChecklistGuia>): List<Long>
+
+    @Update
+    suspend fun atualizar(item: ItemChecklistGuia)
+
+    @Update
+    suspend fun atualizarVarios(itens: List<ItemChecklistGuia>)
+
+
+    @Delete
+    suspend fun deletar(item: ItemChecklistGuia)
+
+    @Query("DELETE FROM itens_checklist_guia WHERE guiaAprendizagemId = :guiaId")
+    suspend fun deletarPorGuiaId(guiaId: Int)
+
+    @Query("SELECT * FROM itens_checklist_guia WHERE guiaAprendizagemId = :guiaId ORDER BY id ASC")
+    fun buscarPorGuiaId(guiaId: Int): Flow<List<ItemChecklistGuia>>
+
+    @Query("SELECT * FROM itens_checklist_guia WHERE id = :id")
+    suspend fun buscarPorId(id: Int): ItemChecklistGuia?
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/PlanoDeAula.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/PlanoDeAula.kt
@@ -1,0 +1,46 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+
+@Entity(
+    tableName = "planos_de_aula",
+    foreignKeys = [
+        ForeignKey(
+            entity = HorarioAula::class,
+            parentColumns = ["id"],
+            childColumns = ["horarioAulaId"],
+            onDelete = ForeignKey.SET_NULL // Se HorarioAula for deletado, seta horarioAulaId para NULL
+        ),
+        ForeignKey(
+            entity = Disciplina::class,
+            parentColumns = ["id"],
+            childColumns = ["disciplinaId"],
+            onDelete = ForeignKey.CASCADE // Se Disciplina for deletada, o PlanoDeAula associado é deletado
+        ),
+        ForeignKey(
+            entity = Turma::class,
+            parentColumns = ["id"],
+            childColumns = ["turmaId"],
+            onDelete = ForeignKey.SET_NULL // Se Turma for deletada, seta turmaId para NULL
+        )
+        // ForeignKey para TemplatePlanoAula será adicionada depois se templateUsadoId for usado
+    ],
+    indices = [
+        Index(value = ["horarioAulaId"]),
+        Index(value = ["disciplinaId"]),
+        Index(value = ["turmaId"]),
+        Index(value = ["template_usado_id"]) // Adicionar índice mesmo que a FK seja futura
+    ]
+)
+data class PlanoDeAula(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val horarioAulaId: Int?, // Pode ser nulo se o plano não estiver vinculado a um horário específico
+    @ColumnInfo(name = "data_aula") val dataAula: String?, // YYYY-MM-DD, pode ser nulo se vinculado a um horário recorrente
+    val disciplinaId: Int,
+    val turmaId: Int?, // Pode ser nulo
+    @ColumnInfo(name = "titulo_plano") val tituloPlano: String?,
+    @ColumnInfo(name = "texto_plano", typeAffinity = ColumnInfo.TEXT) val textoPlano: String?,
+    @ColumnInfo(name = "caminho_anexo") val caminhoAnexo: String?, // URI como String
+    @ColumnInfo(name = "tipo_anexo") val tipoAnexo: String?, // Ex: "image/jpeg", "application/pdf"
+    @ColumnInfo(name = "template_usado_id") val templateUsadoId: Int? = null
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/PlanoDeAulaDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/PlanoDeAulaDao.kt
@@ -1,0 +1,66 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface PlanoDeAulaDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserir(plano: PlanoDeAula): Long
+
+    @Update
+    suspend fun atualizar(plano: PlanoDeAula)
+
+    @Delete
+    suspend fun deletar(plano: PlanoDeAula)
+
+    @Query("SELECT * FROM planos_de_aula WHERE id = :id")
+    suspend fun buscarPorId(id: Int): PlanoDeAula?
+
+    @Query("SELECT * FROM planos_de_aula WHERE horarioAulaId = :horarioId")
+    fun buscarPorHorarioAulaId(horarioId: Int): Flow<List<PlanoDeAula>>
+
+    // Buscar planos por disciplinaId, ordenados pela data da aula (mais recentes primeiro)
+    // Se data_aula for nula, esses podem aparecer no final ou no início dependendo do NULLS LAST/FIRST do SQLite
+    @Query("SELECT * FROM planos_de_aula WHERE disciplinaId = :disciplinaId ORDER BY data_aula DESC, id DESC")
+    fun buscarPorDisciplina(disciplinaId: Int): Flow<List<PlanoDeAula>>
+
+    // Buscar todos os planos, ordenados pela data da aula (mais recentes primeiro)
+    @Query("SELECT * FROM planos_de_aula ORDER BY data_aula DESC, id DESC")
+    fun buscarTodos(): Flow<List<PlanoDeAula>>
+
+    // Query para buscar planos associados a uma disciplina e uma turma específica
+    @Query("SELECT * FROM planos_de_aula WHERE disciplinaId = :disciplinaId AND turmaId = :turmaId ORDER BY data_aula DESC, id DESC")
+    fun buscarPorDisciplinaETurma(disciplinaId: Int, turmaId: Int): Flow<List<PlanoDeAula>>
+
+    // Query para buscar planos por uma data específica
+    @Query("SELECT * FROM planos_de_aula WHERE data_aula = :data ORDER BY id DESC")
+    fun buscarPorData(data: String): Flow<List<PlanoDeAula>>
+
+    @Transaction
+    @Query("""
+        SELECT pda.*,
+               d.nome_disciplina AS nome_disciplina, d.cor AS cor_disciplina,
+               t.nome_turma AS nome_turma, t.cor AS cor_turma
+        FROM planos_de_aula pda
+        INNER JOIN disciplinas d ON pda.disciplinaId = d.id
+        LEFT JOIN turmas t ON pda.turmaId = t.id
+        ORDER BY pda.data_aula DESC, pda.id DESC
+    """)
+    fun buscarTodosParaDisplay(): Flow<List<com.agendafocopei.ui.model.PlanoDeAulaDisplay>>
+
+    @Transaction
+    @Query("""
+        SELECT pda.*,
+               d.nome_disciplina AS nome_disciplina, d.cor AS cor_disciplina,
+               t.nome_turma AS nome_turma, t.cor AS cor_turma
+        FROM planos_de_aula pda
+        INNER JOIN disciplinas d ON pda.disciplinaId = d.id
+        LEFT JOIN turmas t ON pda.turmaId = t.id
+        WHERE pda.id = :planoId
+    """)
+    suspend fun buscarDisplayPorId(planoId: Int): com.agendafocopei.ui.model.PlanoDeAulaDisplay?
+
+    @Query("SELECT * FROM planos_de_aula WHERE horarioAulaId = :horarioId LIMIT 1")
+    suspend fun buscarUmPorHorarioAulaId(horarioId: Int): PlanoDeAula?
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/Subtarefa.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/Subtarefa.kt
@@ -1,0 +1,24 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+
+@Entity(
+    tableName = "subtarefas",
+    foreignKeys = [
+        ForeignKey(
+            entity = Tarefa::class,
+            parentColumns = ["id"],
+            childColumns = ["tarefaId"],
+            onDelete = ForeignKey.CASCADE // Se a Tarefa pai for deletada, as subtarefas também serão
+        )
+    ],
+    indices = [Index(value = ["tarefaId"])]
+)
+data class Subtarefa(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    val tarefaId: Int,
+    @ColumnInfo(name = "descricao_subtarefa") var descricaoSubtarefa: String,
+    var concluida: Boolean = false,
+    @ColumnInfo(defaultValue = "0") // Para ordenação futura, ou pode ser timestamp para ordem de criação
+    var ordem: Int = 0
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/SubtarefaDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/SubtarefaDao.kt
@@ -1,0 +1,28 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SubtarefaDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserir(subtarefa: Subtarefa): Long
+
+    @Update
+    suspend fun atualizar(subtarefa: Subtarefa)
+
+    @Delete
+    suspend fun deletar(subtarefa: Subtarefa)
+
+    @Query("SELECT * FROM subtarefas WHERE tarefaId = :tarefaId ORDER BY ordem ASC, id ASC")
+    fun buscarPorTarefaId(tarefaId: Int): Flow<List<Subtarefa>>
+
+    @Query("SELECT * FROM subtarefas WHERE id = :subtarefaId") // Adicionado para buscar uma subtarefa específica
+    suspend fun buscarPorId(subtarefaId: Int): Subtarefa?
+
+    @Query("DELETE FROM subtarefas WHERE id = :subtarefaId")
+    suspend fun deleteById(subtarefaId: Int)
+
+    @Query("DELETE FROM subtarefas WHERE tarefaId = :tarefaId")
+    suspend fun deleteTodasPorTarefaId(tarefaId: Int)
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/Tarefa.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/Tarefa.kt
@@ -1,0 +1,43 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+
+@Entity(
+    tableName = "tarefas",
+    foreignKeys = [
+        ForeignKey(
+            entity = Disciplina::class,
+            parentColumns = ["id"],
+            childColumns = ["disciplinaId"],
+            onDelete = ForeignKey.SET_NULL // Se Disciplina for deletada, disciplinaId se torna NULL
+        ),
+        ForeignKey(
+            entity = Turma::class,
+            parentColumns = ["id"],
+            childColumns = ["turmaId"],
+            onDelete = ForeignKey.SET_NULL // Se Turma for deletada, turmaId se torna NULL
+        )
+    ],
+    indices = [
+        Index(value = ["disciplinaId"]),
+        Index(value = ["turmaId"]),
+        Index(value = ["prazo_data"]), // Índice para query de tarefas urgentes e por data
+        Index(value = ["concluida"])   // Índice para query de pendentes/concluídas
+    ]
+)
+data class Tarefa(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    var descricao: String,
+    @ColumnInfo(name = "prazo_data") var prazoData: String?, // Formato "YYYY-MM-DD"
+    @ColumnInfo(name = "prazo_hora") var prazoHora: String?, // Formato "HH:mm"
+    var prioridade: Int, // 0: Baixa, 1: Média, 2: Alta
+    var disciplinaId: Int?,
+    var turmaId: Int?,
+    var concluida: Boolean = false,
+    @ColumnInfo(name = "data_criacao", defaultValue = "0") // DefaultValue para migração e inserção
+    val dataCriacao: Long = System.currentTimeMillis(),
+    @ColumnInfo(name = "data_conclusao") var dataConclusao: Long? = null,
+    @ColumnInfo(name = "lembrete_configurado", defaultValue = "0") // DefaultValue para migração e inserção
+    var lembreteConfigurado: Boolean = false,
+    @ColumnInfo(name = "lembrete_datetime") var lembreteDateTime: Long? = null // Timestamp Epoch Millis
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/TarefaDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/TarefaDao.kt
@@ -1,0 +1,96 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TarefaDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserir(tarefa: Tarefa): Long
+
+    @Update
+    suspend fun atualizar(tarefa: Tarefa)
+
+    @Delete
+    suspend fun deletar(tarefa: Tarefa)
+
+    @Query("DELETE FROM tarefas WHERE id = :id")
+    suspend fun deleteById(id: Int)
+
+    @Query("SELECT * FROM tarefas WHERE id = :id")
+    suspend fun buscarPorId(id: Int): Tarefa?
+
+    @Query("SELECT * FROM tarefas ORDER BY data_criacao DESC")
+    fun buscarTodas(): Flow<List<Tarefa>>
+
+    // Ordena pendentes por prioridade (mais alta primeiro), depois por prazo (mais cedo primeiro)
+    @Query("SELECT * FROM tarefas WHERE concluida = 0 ORDER BY prioridade DESC, prazo_data ASC, prazo_hora ASC, data_criacao ASC")
+    fun buscarPendentesOrdenadas(): Flow<List<Tarefa>>
+
+    @Query("SELECT * FROM tarefas WHERE concluida = 1 ORDER BY data_conclusao DESC")
+    fun buscarConcluidasOrdenadas(): Flow<List<Tarefa>>
+
+    // Para RF-02.3: Tarefas urgentes (prazo hoje ou amanhã, não concluídas)
+    // dataHojeNoFormatoYYYYMMDD e dataAmanhaNoFormatoYYYYMMDD precisam ser passadas como argumento
+    @Query("""
+        SELECT * FROM tarefas
+        WHERE concluida = 0 AND prazo_data IS NOT NULL AND
+              (prazo_data = :dataHojeNoFormatoYYYYMMDD OR prazo_data = :dataAmanhaNoFormatoYYYYMMDD)
+        ORDER BY prazo_data ASC, prazo_hora ASC, prioridade DESC
+        LIMIT 5
+    """)
+    fun buscarTarefasUrgentes(dataHojeNoFormatoYYYYMMDD: String, dataAmanhaNoFormatoYYYYMMDD: String): Flow<List<Tarefa>>
+
+    // Query para buscar tarefas com prazo em um dia específico
+    @Query("SELECT * FROM tarefas WHERE prazo_data = :data ORDER BY prazo_hora ASC, prioridade DESC")
+    fun buscarPorDataDePrazo(data: String): Flow<List<Tarefa>>
+
+    // Query para buscar tarefas por disciplina
+    @Query("SELECT * FROM tarefas WHERE disciplinaId = :disciplinaId ORDER BY prazo_data ASC, prioridade DESC")
+    fun buscarPorDisciplina(disciplinaId: Int): Flow<List<Tarefa>>
+
+    // Query para buscar tarefas por turma
+    @Query("SELECT * FROM tarefas WHERE turmaId = :turmaId ORDER BY prazo_data ASC, prioridade DESC")
+    fun buscarPorTurma(turmaId: Int): Flow<List<Tarefa>>
+
+    @Transaction
+    @Query("""
+        SELECT t.*,
+               d.nome_disciplina AS nome_disciplina, d.cor AS cor_disciplina,
+               tu.nome_turma AS nome_turma, tu.cor AS cor_turma
+        FROM tarefas t
+        LEFT JOIN disciplinas d ON t.disciplinaId = d.id
+        LEFT JOIN turmas tu ON t.turmaId = tu.id
+        WHERE t.concluida = 0
+        ORDER BY t.prioridade DESC, t.prazo_data ASC, t.prazo_hora ASC, t.data_criacao ASC
+    """)
+    fun buscarPendentesParaDisplay(): Flow<List<com.agendafocopei.ui.model.TarefaDisplay>>
+
+    @Transaction
+    @Query("""
+        SELECT t.*,
+               d.nome_disciplina AS nome_disciplina, d.cor AS cor_disciplina,
+               tu.nome_turma AS nome_turma, tu.cor AS cor_turma
+        FROM tarefas t
+        LEFT JOIN disciplinas d ON t.disciplinaId = d.id
+        LEFT JOIN turmas tu ON t.turmaId = tu.id
+        WHERE t.concluida = 1
+        ORDER BY t.data_conclusao DESC
+    """)
+    fun buscarConcluidasParaDisplay(): Flow<List<com.agendafocopei.ui.model.TarefaDisplay>>
+
+    @Transaction
+    @Query("""
+        SELECT t.*,
+               d.nome_disciplina AS nome_disciplina, d.cor AS cor_disciplina,
+               tu.nome_turma AS nome_turma, tu.cor AS cor_turma
+        FROM tarefas t
+        LEFT JOIN disciplinas d ON t.disciplinaId = d.id
+        LEFT JOIN turmas tu ON t.turmaId = tu.id
+        WHERE t.concluida = 0 AND t.prazo_data IS NOT NULL AND
+              (t.prazo_data = :dataHoje OR t.prazo_data = :dataAmanha)
+        ORDER BY t.prazo_data ASC, t.prazo_hora ASC, t.prioridade DESC
+        LIMIT 5
+    """)
+    fun buscarUrgentesParaDisplay(dataHoje: String, dataAmanha: String): Flow<List<com.agendafocopei.ui.model.TarefaDisplay>>
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/TemplatePlanoAula.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/TemplatePlanoAula.kt
@@ -1,0 +1,14 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+
+@Entity(tableName = "templates_plano_aula")
+data class TemplatePlanoAula(
+    @PrimaryKey(autoGenerate = true) val id: Int = 0,
+    @ColumnInfo(name = "nome_template") val nomeTemplate: String,
+    @ColumnInfo(name = "campo_habilidades", typeAffinity = ColumnInfo.TEXT) val campoHabilidades: String?,
+    @ColumnInfo(name = "campo_recursos", typeAffinity = ColumnInfo.TEXT) val campoRecursos: String?,
+    @ColumnInfo(name = "campo_metodologia", typeAffinity = ColumnInfo.TEXT) val campoMetodologia: String?,
+    @ColumnInfo(name = "campo_avaliacao", typeAffinity = ColumnInfo.TEXT) val campoAvaliacao: String?,
+    @ColumnInfo(name = "outros_campos", typeAffinity = ColumnInfo.TEXT) val outrosCampos: String? // JSON String para campos customizados
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/TemplatePlanoAulaDao.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/data/TemplatePlanoAulaDao.kt
@@ -1,0 +1,22 @@
+package com.agendafocopei.data
+
+import androidx.room.*
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface TemplatePlanoAulaDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun inserir(template: TemplatePlanoAula): Long
+
+    @Update
+    suspend fun atualizar(template: TemplatePlanoAula)
+
+    @Delete
+    suspend fun deletar(template: TemplatePlanoAula)
+
+    @Query("SELECT * FROM templates_plano_aula WHERE id = :id")
+    suspend fun buscarPorId(id: Int): TemplatePlanoAula?
+
+    @Query("SELECT * FROM templates_plano_aula ORDER BY nome_template ASC")
+    fun buscarTodos(): Flow<List<TemplatePlanoAula>>
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/AnotacoesActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/AnotacoesActivity.kt
@@ -1,0 +1,132 @@
+package com.agendafocopei.ui.activity
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.Anotacao
+import com.agendafocopei.data.AnotacaoDao
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.TurmaDao
+import com.agendafocopei.databinding.ActivityAnotacoesBinding
+import com.agendafocopei.ui.adapter.AnotacaoAdapter
+// import com.agendafocopei.ui.dialog.FormularioAnotacaoFragment // Será criado no próximo subtask
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+// Removido FormularioAnotacaoFragment.FormularioAnotacaoListener por enquanto
+class AnotacoesActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityAnotacoesBinding
+    private lateinit var anotacaoAdapter: AnotacaoAdapter
+    private lateinit var anotacaoDao: AnotacaoDao
+    private lateinit var turmaDao: TurmaDao
+
+    companion object {
+        const val EXTRA_ABRIR_FORMULARIO_NOVA_ANOTACAO = "abrir_formulario_nova_anotacao"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityAnotacoesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val db = AppDatabase.getDatabase(applicationContext)
+        anotacaoDao = db.anotacaoDao()
+        turmaDao = db.turmaDao()
+
+        setSupportActionBar(binding.toolbarAnotacoes)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupRecyclerView()
+        observeAnotacoes()
+
+        binding.fabAdicionarAnotacao.setOnClickListener {
+            abrirFormularioAnotacao(null)
+        }
+
+        if (intent.getBooleanExtra(EXTRA_ABRIR_FORMULARIO_NOVA_ANOTACAO, false)) {
+            intent.removeExtra(EXTRA_ABRIR_FORMULARIO_NOVA_ANOTACAO)
+            abrirFormularioAnotacao(null)
+        }
+    }
+
+    private fun setupRecyclerView() {
+        anotacaoAdapter = AnotacaoAdapter(
+            turmaDao = turmaDao,
+            onItemClickListener = { anotacao ->
+                abrirFormularioAnotacao(anotacao.id)
+            },
+            onEditClickListener = { anotacao ->
+                abrirFormularioAnotacao(anotacao.id)
+            },
+            onDeleteClickListener = { anotacao ->
+                mostrarDialogoConfirmacaoDelete(anotacao)
+            }
+        )
+        binding.recyclerViewAnotacoes.apply {
+            adapter = anotacaoAdapter
+            layoutManager = LinearLayoutManager(this@AnotacoesActivity)
+        }
+    }
+
+    private fun observeAnotacoes() {
+        lifecycleScope.launch {
+            anotacaoDao.buscarTodas().collect { listaAnotacoes ->
+                anotacaoAdapter.submitList(listaAnotacoes)
+                binding.textViewListaVaziaAnotacoes.visibility = if (listaAnotacoes.isEmpty()) View.VISIBLE else View.GONE
+                binding.recyclerViewAnotacoes.visibility = if (listaAnotacoes.isEmpty()) View.GONE else View.VISIBLE
+            }
+        }
+    }
+
+    private fun abrirFormularioAnotacao(anotacaoId: Int?) {
+        val mensagem = if (anotacaoId == null) "Abrir formulário para Nova Anotação" else "Abrir formulário para Editar Anotação ID: $anotacaoId"
+        Toast.makeText(this, "$mensagem (Formulário a ser implementado no próximo passo)", Toast.LENGTH_LONG).show()
+
+        // Quando FormularioAnotacaoFragment estiver pronto:
+        // val formularioDialog = FormularioAnotacaoFragment.newInstance(anotacaoId)
+        // formularioDialog.setListener(this) // Se AnotacoesActivity implementar o listener
+        // formularioDialog.show(supportFragmentManager, FormularioAnotacaoFragment.TAG)
+    }
+
+    // Implementar FormularioAnotacaoFragment.FormularioAnotacaoListener quando o fragmento for criado
+    // override fun onAnotacaoSalva(anotacao: Anotacao) {
+    //     lifecycleScope.launch(Dispatchers.IO) {
+    //         anotacaoDao.inserir(anotacao) // OnConflict REPLACE
+    //         withContext(Dispatchers.Main) {
+    //             Toast.makeText(this@AnotacoesActivity, "Anotação salva!", Toast.LENGTH_SHORT).show()
+    //         }
+    //     }
+    // }
+
+    private fun mostrarDialogoConfirmacaoDelete(anotacao: Anotacao) {
+        AlertDialog.Builder(this)
+            .setTitle("Confirmar Exclusão")
+            .setMessage("Tem certeza que deseja excluir esta anotação?")
+            .setPositiveButton("Excluir") { _, _ ->
+                deletarAnotacao(anotacao)
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun deletarAnotacao(anotacao: Anotacao) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            anotacaoDao.deletar(anotacao)
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@AnotacoesActivity, "Anotação excluída.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/DashboardActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/DashboardActivity.kt
@@ -103,18 +103,23 @@ class DashboardActivity : AppCompatActivity() {
         }
     }
 
-    private fun atualizarUIProximoCompromisso(proximaAula: HorarioAulaDisplay?, proximoEvento: EventoRecorrente?) {
-        val cardProximoCompromisso = binding.cardViewProximoCompromisso // Usando ViewBinding
+    private fun atualizarUIProximoCompromisso(proximaAula: HorarioAulaDisplay?, proximoEvento: Evento?) {
+        // val cardProximoCompromisso = binding.cardViewProximoCompromisso // Não muda mais o fundo do card
+        val indicadorCor = binding.viewCorProximoCompromissoIndicador // Nova View para a cor
 
         val nenhumCompromisso = proximaAula == null && proximoEvento == null
         binding.textViewNenhumCompromissoHoje.visibility = if (nenhumCompromisso) View.VISIBLE else View.GONE
 
+        // Controla a visibilidade do Card inteiro baseado na existência de compromissos
+        binding.cardViewProximoCompromisso.visibility = if (nenhumCompromisso) View.GONE else View.VISIBLE
+        // Se não há compromissos, o título da seção também pode ser ocultado ou modificado
+        binding.textViewTituloProximoCompromisso.text = if (nenhumCompromisso) "Próximo Compromisso: Nenhum" else "Próximo Compromisso:"
+
+
         if (nenhumCompromisso) {
-            binding.textViewHorarioProximoCompromisso.visibility = View.GONE
-            binding.textViewNomeProximoCompromisso.visibility = View.GONE
-            binding.textViewTurmaProximoCompromisso.visibility = View.GONE
-            binding.textViewSalaLocalProximoCompromisso.visibility = View.GONE
-            cardProximoCompromisso.setCardBackgroundColor(Color.TRANSPARENT) // Ou cor padrão
+            // Os TextViews dentro do card serão ocultados pelo card pai se o card for GONE
+            // Mas para garantir, podemos ocultá-los também ou apenas retornar.
+            indicadorCor.setBackgroundColor(Color.TRANSPARENT)
             return
         }
 
@@ -174,7 +179,8 @@ class DashboardActivity : AppCompatActivity() {
             binding.textViewTurmaProximoCompromisso.visibility = View.GONE
         }
 
-        cardProximoCompromisso.setCardBackgroundColor(compromissoCor ?: Color.parseColor("#E0E0E0"))
+        // cardProximoCompromisso.setCardBackgroundColor(compromissoCor ?: Color.parseColor("#E0E0E0"))
+        indicadorCor.setBackgroundColor(compromissoCor ?: Color.TRANSPARENT) // Usa cor padrão ou transparente se nula
     }
 
     private fun carregarAgendaDoDia() {

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/DetalhesGuiaActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/DetalhesGuiaActivity.kt
@@ -1,0 +1,182 @@
+package com.agendafocopei.ui.activity
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.*
+import com.agendafocopei.databinding.ActivityDetalhesGuiaBinding
+import com.agendafocopei.ui.adapter.ItemChecklistGuiaAdapter
+import com.agendafocopei.ui.model.GuiaDeAprendizagemDisplay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class DetalhesGuiaActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityDetalhesGuiaBinding
+    private lateinit var itemChecklistAdapter: ItemChecklistGuiaAdapter
+    private lateinit var guiaDao: GuiaDeAprendizagemDao
+    private lateinit var itemChecklistDao: ItemChecklistGuiaDao
+    private var guiaId: Int = -1
+    private var guiaAtual: GuiaDeAprendizagemDisplay? = null
+
+    companion object {
+        const val EXTRA_GUIA_ID = "extra_guia_id"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityDetalhesGuiaBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        guiaId = intent.getIntExtra(EXTRA_GUIA_ID, -1)
+        if (guiaId == -1) {
+            Toast.makeText(this, "ID do Guia inválido.", Toast.LENGTH_LONG).show()
+            finish()
+            return
+        }
+
+        val db = AppDatabase.getDatabase(applicationContext)
+        guiaDao = db.guiaDeAprendizagemDao()
+        itemChecklistDao = db.itemChecklistGuiaDao()
+
+        setSupportActionBar(binding.toolbarDetalhesGuia)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupRecyclerView()
+        loadGuiaDetalhes()
+        observeChecklistItens()
+
+        binding.buttonAdicionarItemChecklist.setOnClickListener {
+            adicionarNovoItemChecklist()
+        }
+
+        binding.buttonVerDocumentoAnexadoGuia.setOnClickListener {
+            abrirDocumentoAnexado()
+        }
+    }
+
+    private fun setupRecyclerView() {
+        itemChecklistAdapter = ItemChecklistGuiaAdapter(
+            onItemCheckChanged = { item, isChecked ->
+                lifecycleScope.launch(Dispatchers.IO) {
+                    itemChecklistDao.atualizar(item.copy(concluido = isChecked))
+                }
+            },
+            onDeleteItemClickListener = { item ->
+                mostrarDialogoConfirmacaoDeleteChecklistItem(item)
+            }
+        )
+        binding.recyclerViewItensChecklist.apply {
+            adapter = itemChecklistAdapter
+            layoutManager = LinearLayoutManager(this@DetalhesGuiaActivity)
+        }
+    }
+
+    private fun loadGuiaDetalhes() {
+        lifecycleScope.launch {
+            guiaAtual = withContext(Dispatchers.IO) { guiaDao.buscarDisplayPorId(guiaId) }
+            guiaAtual?.let { display ->
+                val guia = display.guiaDeAprendizagem
+                val tituloGerado = "Guia: ${display.nomeDisciplina ?: ""} - ${guia.bimestre} ${guia.ano}"
+                binding.textViewTituloDetalhesGuia.text = guia.tituloGuia ?: tituloGerado
+                binding.textViewDisciplinaDetalhesGuia.text = "Disciplina: ${display.nomeDisciplina ?: "N/A"}"
+                binding.textViewBimestreAnoDetalhesGuia.text = "${guia.bimestre} - ${guia.ano}"
+
+                if (guia.caminhoAnexoGuia != null) {
+                    binding.buttonVerDocumentoAnexadoGuia.visibility = View.VISIBLE
+                } else {
+                    binding.buttonVerDocumentoAnexadoGuia.visibility = View.GONE
+                }
+            } ?: run {
+                Toast.makeText(this@DetalhesGuiaActivity, "Guia não encontrado.", Toast.LENGTH_LONG).show()
+                finish()
+            }
+        }
+    }
+
+    private fun observeChecklistItens() {
+        lifecycleScope.launch {
+            itemChecklistDao.buscarPorGuiaId(guiaId).collectLatest { itens ->
+                itemChecklistAdapter.submitList(itens)
+                binding.textViewChecklistVazio.visibility = if (itens.isEmpty()) View.VISIBLE else View.GONE
+                binding.recyclerViewItensChecklist.visibility = if (itens.isEmpty()) View.GONE else View.VISIBLE
+            }
+        }
+    }
+
+    private fun adicionarNovoItemChecklist() {
+        val descricao = binding.editTextNovoItemChecklist.text.toString().trim()
+        if (descricao.isNotEmpty()) {
+            lifecycleScope.launch(Dispatchers.IO) {
+                itemChecklistDao.inserir(
+                    ItemChecklistGuia(
+                        guiaAprendizagemId = guiaId,
+                        descricaoItem = descricao,
+                        concluido = false
+                    )
+                )
+            }
+            binding.editTextNovoItemChecklist.text?.clear()
+        } else {
+            Toast.makeText(this, "Descrição do item não pode ser vazia.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun mostrarDialogoConfirmacaoDeleteChecklistItem(item: ItemChecklistGuia) {
+        AlertDialog.Builder(this)
+            .setTitle("Confirmar Exclusão")
+            .setMessage("Tem certeza que deseja excluir o item \"${item.descricaoItem}\"?")
+            .setPositiveButton("Excluir") { _, _ ->
+                deletarChecklistItem(item)
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun deletarChecklistItem(item: ItemChecklistGuia) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            itemChecklistDao.deletar(item)
+        }
+    }
+
+    private fun abrirDocumentoAnexado() {
+        guiaAtual?.guiaDeAprendizagem?.caminhoAnexoGuia?.let { uriString ->
+            val uri = Uri.parse(uriString)
+            val mimeType = guiaAtual?.guiaDeAprendizagem?.tipoAnexoGuia
+
+            val intent = Intent(Intent.ACTION_VIEW).apply {
+                setDataAndType(uri, mimeType ?: "*/*") // Se tipo MIME não conhecido, usa genérico
+                addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION) // Necessário para URIs de conteúdo
+            }
+            try {
+                startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                Toast.makeText(this, "Nenhum aplicativo encontrado para abrir este tipo de arquivo.", Toast.LENGTH_LONG).show()
+            }
+        } ?: Toast.makeText(this, "Nenhum documento anexado.", Toast.LENGTH_SHORT).show()
+    }
+
+
+    override fun onSupportNavigateUp(): Boolean {
+        // Informa a activity anterior que pode ter havido mudanças (ex: progresso do checklist)
+        setResult(Activity.RESULT_OK)
+        finish()
+        return true
+    }
+
+    @Deprecated("Deprecated in Java")
+    override fun onBackPressed() {
+        setResult(Activity.RESULT_OK)
+        super.onBackPressed()
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/GuiasDeAprendizagemActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/GuiasDeAprendizagemActivity.kt
@@ -1,0 +1,133 @@
+package com.agendafocopei.ui.activity
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.GuiaDeAprendizagem
+import com.agendafocopei.data.GuiaDeAprendizagemDao
+import com.agendafocopei.databinding.ActivityGuiasDeAprendizagemBinding
+import com.agendafocopei.ui.adapter.GuiaDeAprendizagemAdapter
+import com.agendafocopei.ui.dialog.FormularioGuiaFragment
+import com.agendafocopei.ui.model.GuiaDeAprendizagemDisplay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class GuiasDeAprendizagemActivity : AppCompatActivity(), FormularioGuiaFragment.FormularioGuiaListener {
+
+    private lateinit var binding: ActivityGuiasDeAprendizagemBinding
+    private lateinit var guiaAdapter: GuiaDeAprendizagemAdapter
+    private lateinit var guiaDao: GuiaDeAprendizagemDao
+
+    companion object {
+        const val REQUEST_CODE_DETALHES_GUIA = 101
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityGuiasDeAprendizagemBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        guiaDao = AppDatabase.getDatabase(applicationContext).guiaDeAprendizagemDao()
+
+        setSupportActionBar(binding.toolbarGuias)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupRecyclerView()
+        observeGuias()
+
+        binding.fabAdicionarGuia.setOnClickListener {
+            FormularioGuiaFragment.newInstance(null).also {
+                it.setListener(this)
+                it.show(supportFragmentManager, FormularioGuiaFragment.TAG)
+            }
+        }
+    }
+
+    private fun setupRecyclerView() {
+        guiaAdapter = GuiaDeAprendizagemAdapter(
+            onDetalhesClickListener = { guiaDisplay ->
+                val intent = Intent(this, DetalhesGuiaActivity::class.java)
+                intent.putExtra(DetalhesGuiaActivity.EXTRA_GUIA_ID, guiaDisplay.guiaDeAprendizagem.id)
+                startActivityForResult(intent, REQUEST_CODE_DETALHES_GUIA) // Se precisar atualizar algo ao voltar
+            },
+            onEditClickListener = { guiaDisplay ->
+                FormularioGuiaFragment.newInstance(guiaDisplay.guiaDeAprendizagem.id).also {
+                    it.setListener(this)
+                    it.show(supportFragmentManager, FormularioGuiaFragment.TAG)
+                }
+            },
+            onDeleteClickListener = { guiaDisplay ->
+                mostrarDialogoConfirmacaoDelete(guiaDisplay.guiaDeAprendizagem)
+            }
+        )
+        binding.recyclerViewGuias.apply {
+            adapter = guiaAdapter
+            layoutManager = LinearLayoutManager(this@GuiasDeAprendizagemActivity)
+        }
+    }
+
+    private fun observeGuias() {
+        lifecycleScope.launch {
+            guiaDao.buscarTodosParaDisplay().collect { listaGuias ->
+                guiaAdapter.submitList(listaGuias)
+                if (listaGuias.isEmpty()) {
+                    binding.textViewListaVaziaGuias.visibility = View.VISIBLE
+                    binding.recyclerViewGuias.visibility = View.GONE
+                } else {
+                    binding.textViewListaVaziaGuias.visibility = View.GONE
+                    binding.recyclerViewGuias.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+
+    private fun mostrarDialogoConfirmacaoDelete(guia: GuiaDeAprendizagem) {
+        AlertDialog.Builder(this)
+            .setTitle("Confirmar Exclusão")
+            .setMessage("Tem certeza que deseja excluir o guia \"${guia.tituloGuia ?: "${guia.bimestre} ${guia.ano}"}\"? Isso também excluirá todos os itens do checklist associados.")
+            .setPositiveButton("Excluir") { _, _ ->
+                deletarGuia(guia)
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun deletarGuia(guia: GuiaDeAprendizagem) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            guiaDao.deletar(guia) // CASCADE deve cuidar dos itens do checklist
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@GuiasDeAprendizagemActivity, "Guia excluído.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onGuiaSalvo(guia: GuiaDeAprendizagem) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            guiaDao.inserir(guia)
+            withContext(Dispatchers.Main) {
+                 Toast.makeText(this@GuiasDeAprendizagemActivity, "Guia salvo!", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    // Se precisar atualizar a lista após DetalhesGuiaActivity (ex: se checklist progresso mudou)
+    // override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+    //     super.onActivityResult(requestCode, resultCode, data)
+    //     if (requestCode == REQUEST_CODE_DETALHES_GUIA && resultCode == Activity.RESULT_OK) {
+    //         // Potencialmente recarregar ou notificar adapter se houver mudanças visíveis na lista
+    //     }
+    // }
+
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/PlanosDeAulaGeralActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/PlanosDeAulaGeralActivity.kt
@@ -1,0 +1,138 @@
+package com.agendafocopei.ui.activity
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.PlanoDeAula
+import com.agendafocopei.data.PlanoDeAulaDao
+import com.agendafocopei.databinding.ActivityPlanosDeAulaGeralBinding
+import com.agendafocopei.ui.adapter.PlanoDeAulaAdapter
+import com.agendafocopei.ui.dialog.FormularioPlanoDeAulaFragment
+import com.agendafocopei.ui.model.PlanoDeAulaDisplay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class PlanosDeAulaGeralActivity : AppCompatActivity(), FormularioPlanoDeAulaFragment.FormularioPlanoListener {
+
+    private lateinit var binding: ActivityPlanosDeAulaGeralBinding
+    private lateinit var planoDeAulaAdapter: PlanoDeAulaAdapter
+    private lateinit var planoDeAulaDao: PlanoDeAulaDao
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPlanosDeAulaGeralBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        planoDeAulaDao = AppDatabase.getDatabase(applicationContext).planoDeAulaDao()
+
+        setSupportActionBar(binding.toolbarPlanosDeAula)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        // Título já definido no XML
+
+        setupRecyclerView()
+        observePlanosDeAula()
+
+        binding.fabAdicionarPlanoDeAula.setOnClickListener {
+            FormularioPlanoDeAulaFragment.newInstance(
+                planoId = null, // Novo plano
+                horarioAulaId = null, // Não vinculado a um horário específico inicialmente
+                disciplinaIdPredefinida = null, // Sem predefinição
+                turmaIdPredefinida = null,
+                dataPredefinida = null
+            ).also {
+                it.setListener(this)
+                it.show(supportFragmentManager, FormularioPlanoDeAulaFragment.TAG)
+            }
+        }
+    }
+
+    private fun setupRecyclerView() {
+        planoDeAulaAdapter = PlanoDeAulaAdapter(
+            onEditClickListener = { planoDisplay ->
+                FormularioPlanoDeAulaFragment.newInstance(
+                    planoId = planoDisplay.planoDeAula.id,
+                    // Outros IDs predefinidos podem ser passados se disponíveis/necessários
+                    // horarioAulaId = planoDisplay.planoDeAula.horarioAulaId,
+                    // disciplinaIdPredefinida = planoDisplay.planoDeAula.disciplinaId,
+                    // turmaIdPredefinida = planoDisplay.planoDeAula.turmaId,
+                    // dataPredefinida = planoDisplay.planoDeAula.dataAula
+                ).also {
+                    it.setListener(this)
+                    it.show(supportFragmentManager, FormularioPlanoDeAulaFragment.TAG)
+                }
+            },
+            onDeleteClickListener = { planoDisplay ->
+                mostrarDialogoConfirmacaoDelete(planoDisplay.planoDeAula)
+            },
+            onItemClickListener = { planoDisplay ->
+                // Lógica para visualizar detalhes do plano, se houver uma tela de detalhes.
+                // Por enquanto, pode ser um Toast ou abrir o modo de edição.
+                Toast.makeText(this, "Visualizar: ${planoDisplay.planoDeAula.tituloPlano ?: "Plano"}", Toast.LENGTH_SHORT).show()
+                 FormularioPlanoDeAulaFragment.newInstance(planoDisplay.planoDeAula.id)
+                     .also { it.setListener(this) }
+                     .show(supportFragmentManager, FormularioPlanoDeAulaFragment.TAG)
+            }
+        )
+        binding.recyclerViewPlanosDeAula.apply {
+            adapter = planoDeAulaAdapter
+            layoutManager = LinearLayoutManager(this@PlanosDeAulaGeralActivity)
+        }
+    }
+
+    private fun observePlanosDeAula() {
+        lifecycleScope.launch {
+            planoDeAulaDao.buscarTodosParaDisplay().collect { listaPlanos ->
+                planoDeAulaAdapter.submitList(listaPlanos)
+                if (listaPlanos.isEmpty()) {
+                    binding.textViewListaVaziaPlanos.visibility = View.VISIBLE
+                    binding.recyclerViewPlanosDeAula.visibility = View.GONE
+                } else {
+                    binding.textViewListaVaziaPlanos.visibility = View.GONE
+                    binding.recyclerViewPlanosDeAula.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+
+    private fun mostrarDialogoConfirmacaoDelete(plano: PlanoDeAula) {
+        AlertDialog.Builder(this)
+            .setTitle("Confirmar Exclusão")
+            .setMessage("Tem certeza que deseja excluir o plano \"${plano.tituloPlano ?: "Plano sem título"}\"?")
+            .setPositiveButton("Excluir") { _, _ ->
+                deletarPlano(plano)
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun deletarPlano(plano: PlanoDeAula) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            planoDeAulaDao.deletar(plano)
+            // A UI será atualizada automaticamente pelo Flow
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@PlanosDeAulaGeralActivity, "Plano excluído.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onPlanoSalvo(plano: PlanoDeAula) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            planoDeAulaDao.inserir(plano) // REPLACE strategy lida com insert/update
+            withContext(Dispatchers.Main) {
+                 Toast.makeText(this@PlanosDeAulaGeralActivity, "Plano salvo!", Toast.LENGTH_SHORT).show()
+            }
+            // A UI será atualizada automaticamente pelo Flow
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/PomodoroActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/PomodoroActivity.kt
@@ -1,0 +1,139 @@
+package com.agendafocopei.ui.activity
+
+import android.content.Context
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.activity.viewModels // Para by viewModels()
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.Observer
+import com.agendafocopei.databinding.ActivityPomodoroBinding
+import com.agendafocopei.ui.pomodoro.ConfigPomodoroDialogFragment
+import com.agendafocopei.ui.pomodoro.PomodoroState
+import com.agendafocopei.ui.pomodoro.PomodoroViewModel
+import java.util.concurrent.TimeUnit
+
+class PomodoroActivity : AppCompatActivity(), ConfigPomodoroDialogFragment.ConfigPomodoroListener {
+
+    private lateinit var binding: ActivityPomodoroBinding
+    private val viewModel: PomodoroViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPomodoroBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        // Inicializa ViewModel com SharedPreferences
+        val prefs = getSharedPreferences(PomodoroViewModel.PREFS_NAME, Context.MODE_PRIVATE)
+        viewModel.inicializarComPrefs(prefs)
+
+        // Configurar a Toolbar
+        setSupportActionBar(binding.toolbarPomodoro)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        // O título já está definido no XML
+
+        setupObservers()
+        setupClickListeners()
+    }
+
+    private fun setupObservers() {
+        viewModel.tempoRestanteMillis.observe(this, Observer { millis ->
+            val minutos = TimeUnit.MILLISECONDS.toMinutes(millis)
+            val segundos = TimeUnit.MILLISECONDS.toSeconds(millis) % 60
+            binding.textViewTempoPomodoro.text = String.format("%02d:%02d", minutos, segundos)
+
+            // Atualizar ProgressBar
+            val totalMillis = viewModel.tempoTotalCicloAtualMillis.value ?: millis // Evita divisão por zero
+            if (totalMillis > 0) {
+                val progresso = ((totalMillis - millis).toFloat() / totalMillis * 100).toInt()
+                binding.progressBarPomodoro.progress = progresso
+            } else {
+                binding.progressBarPomodoro.progress = 0
+            }
+        })
+
+        viewModel.estadoAtual.observe(this, Observer { estado ->
+            when (estado) {
+                PomodoroState.PRONTO -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Pronto"
+                    binding.buttonIniciarPausarPomodoro.text = "Iniciar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = false
+                    binding.buttonPularCicloPomodoro.isEnabled = false
+                    binding.progressBarPomodoro.progress = 0
+                }
+                PomodoroState.FOCO -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Foco"
+                    binding.buttonIniciarPausarPomodoro.text = "Pausar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                }
+                PomodoroState.PAUSA_CURTA -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Pausa Curta"
+                    binding.buttonIniciarPausarPomodoro.text = "Pausar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                }
+                PomodoroState.PAUSA_LONGA -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Pausa Longa"
+                    binding.buttonIniciarPausarPomodoro.text = "Pausar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                }
+                PomodoroState.PAUSADO -> {
+                    // Mantém o texto do estado anterior à pausa, ou um genérico "Pausado"
+                    // O ViewModel precisaria expor o estadoAntesDePausar para isso.
+                    // Por simplicidade, vamos usar "Pausado" e o texto do botão indica a ação.
+                    binding.textViewEstadoCicloPomodoro.text = "Pausado"
+                    binding.buttonIniciarPausarPomodoro.text = "Retomar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                }
+                null -> {} // Não deve acontecer
+            }
+        })
+
+        viewModel.cicloFocoAtual.observe(this, Observer { ciclo ->
+             // Assume que _ciclosAtePausaLonga é acessível ou você tem um LiveData para ele
+             // Para simplificar, vou usar um valor fixo aqui, mas idealmente viria do ViewModel
+            val totalCiclosParaPausaLonga = prefs.getInt(PomodoroViewModel.KEY_CICLOS_ATE_PAUSA_LONGA, 4)
+            if (ciclo > 0) {
+                binding.textViewNumeroCicloPomodoro.text = "Ciclo: $ciclo/$totalCiclosParaPausaLonga"
+                binding.textViewNumeroCicloPomodoro.visibility = View.VISIBLE
+            } else {
+                binding.textViewNumeroCicloPomodoro.text = "Ciclo: -/-"
+                // Ou ocultar: binding.textViewNumeroCicloPomodoro.visibility = View.INVISIBLE
+            }
+        })
+    }
+
+    private fun setupClickListeners() {
+        binding.buttonIniciarPausarPomodoro.setOnClickListener {
+            viewModel.iniciarPausar()
+        }
+        binding.buttonResetarPomodoro.setOnClickListener {
+            viewModel.resetarCicloAtualOuPomodoro()
+        }
+        binding.buttonPularCicloPomodoro.setOnClickListener {
+            viewModel.pularParaProximoCiclo()
+        }
+        binding.buttonConfigPomodoro.setOnClickListener {
+            ConfigPomodoroDialogFragment.newInstance().show(supportFragmentManager, ConfigPomodoroDialogFragment.TAG)
+        }
+    }
+
+    // Implementação do ConfigPomodoroListener
+    override fun onConfigSalva(focoMin: Int, curtaMin: Int, longaMin: Int, ciclos: Int, hiperfoco: Boolean, som: Boolean) {
+        viewModel.setConfiguracoes(focoMin, curtaMin, longaMin, ciclos, hiperfoco, som)
+        Toast.makeText(this, "Configurações salvas e aplicadas.", Toast.LENGTH_SHORT).show()
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/TarefasActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/TarefasActivity.kt
@@ -1,0 +1,122 @@
+package com.agendafocopei.ui.activity
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.TarefaDao
+import com.agendafocopei.databinding.ActivityTarefasBinding
+import com.agendafocopei.ui.adapter.TarefaAdapter
+import com.agendafocopei.ui.dialog.FormularioTarefaFragment // Será criado no próximo subtask
+import com.agendafocopei.ui.model.TarefaDisplay
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.*
+
+class TarefasActivity : AppCompatActivity() { // Removido FormularioTarefaFragment.FormularioTarefaListener por enquanto
+
+    private lateinit var binding: ActivityTarefasBinding
+    private lateinit var tarefaAdapter: TarefaAdapter
+    private lateinit var tarefaDao: TarefaDao
+
+    // Launcher para o formulário de tarefa
+    // private lateinit var formularioTarefaLauncher: ActivityResultLauncher<Intent> // Se FormularioTarefaActivity
+    // Se for DialogFragment, a comunicação é via listener
+
+    companion object {
+        const val EXTRA_ABRIR_FORMULARIO_NOVA_TAREFA = "abrir_formulario_nova_tarefa"
+    }
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTarefasBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        tarefaDao = AppDatabase.getDatabase(applicationContext).tarefaDao()
+
+        setSupportActionBar(binding.toolbarTarefas)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupRecyclerView()
+        observeTarefasPendentes() // Por padrão, mostra pendentes
+
+        binding.fabAdicionarTarefa.setOnClickListener {
+            abrirFormularioTarefa(null)
+        }
+
+        if (intent.getBooleanExtra(EXTRA_ABRIR_FORMULARIO_NOVA_TAREFA, false)) {
+            abrirFormularioTarefa(null)
+        }
+    }
+
+    private fun setupRecyclerView() {
+        tarefaAdapter = TarefaAdapter(
+            onTarefaCheckChanged = { tarefaDisplay, isChecked ->
+                lifecycleScope.launch(Dispatchers.IO) {
+                    val tarefaAtualizada = tarefaDisplay.tarefa.copy(
+                        concluida = isChecked,
+                        dataConclusao = if (isChecked) System.currentTimeMillis() else null
+                    )
+                    tarefaDao.atualizar(tarefaAtualizada)
+                    // A lista será atualizada pelo Flow
+                }
+            },
+            onEditClickListener = { tarefaDisplay ->
+                abrirFormularioTarefa(tarefaDisplay.tarefa.id)
+            }
+        )
+        binding.recyclerViewTarefas.apply {
+            adapter = tarefaAdapter
+            layoutManager = LinearLayoutManager(this@TarefasActivity)
+        }
+    }
+
+    private fun observeTarefasPendentes() {
+        lifecycleScope.launch {
+            tarefaDao.buscarPendentesParaDisplay().collect { listaTarefas ->
+                tarefaAdapter.submitList(listaTarefas)
+                binding.textViewListaVaziaTarefas.visibility = if (listaTarefas.isEmpty()) View.VISIBLE else View.GONE
+                binding.recyclerViewTarefas.visibility = if (listaTarefas.isEmpty()) View.GONE else View.VISIBLE
+            }
+        }
+    }
+
+    private fun abrirFormularioTarefa(tarefaId: Int?) {
+        // A implementação do FormularioTarefaFragment será no próximo subtask
+        // Por enquanto, um Toast.
+        val mensagem = if (tarefaId == null) "Abrir formulário para Nova Tarefa" else "Abrir formulário para Editar Tarefa ID: $tarefaId"
+        Toast.makeText(this, "$mensagem (a ser implementado)", Toast.LENGTH_LONG).show()
+
+        // Quando FormularioTarefaFragment estiver pronto:
+        // val formularioDialog = FormularioTarefaFragment.newInstance(tarefaId)
+        // formularioDialog.setListener(this) // Se TarefasActivity implementar o listener
+        // formularioDialog.show(supportFragmentManager, FormularioTarefaFragment.TAG)
+    }
+
+    // Implementar FormularioTarefaFragment.FormularioTarefaListener quando o fragmento for criado
+    // override fun onTarefaSalva(tarefa: Tarefa) {
+    //     lifecycleScope.launch(Dispatchers.IO) {
+    //         tarefaDao.inserir(tarefa) // OnConflict REPLACE
+    //         runOnUiThread {
+    //             Toast.makeText(this@TarefasActivity, "Tarefa salva!", Toast.LENGTH_SHORT).show()
+    //         }
+    //     }
+    // }
+
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/TemplatesPlanoAulaActivity.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/activity/TemplatesPlanoAulaActivity.kt
@@ -1,0 +1,115 @@
+package com.agendafocopei.ui.activity
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.TemplatePlanoAula
+import com.agendafocopei.data.TemplatePlanoAulaDao
+import com.agendafocopei.databinding.ActivityTemplatesPlanoAulaBinding
+import com.agendafocopei.ui.adapter.TemplatePlanoAulaAdapter
+import com.agendafocopei.ui.dialog.FormularioTemplatePlanoAulaFragment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class TemplatesPlanoAulaActivity : AppCompatActivity(), FormularioTemplatePlanoAulaFragment.FormularioTemplateListener {
+
+    private lateinit var binding: ActivityTemplatesPlanoAulaBinding
+    private lateinit var templateAdapter: TemplatePlanoAulaAdapter
+    private lateinit var templateDao: TemplatePlanoAulaDao
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTemplatesPlanoAulaBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        templateDao = AppDatabase.getDatabase(applicationContext).templatePlanoAulaDao()
+
+        setSupportActionBar(binding.toolbarTemplates)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupRecyclerView()
+        observeTemplates()
+
+        binding.fabAdicionarTemplate.setOnClickListener {
+            FormularioTemplatePlanoAulaFragment.newInstance(null).also {
+                it.setListener(this)
+                it.show(supportFragmentManager, FormularioTemplatePlanoAulaFragment.TAG)
+            }
+        }
+    }
+
+    private fun setupRecyclerView() {
+        templateAdapter = TemplatePlanoAulaAdapter(
+            onEditClickListener = { template ->
+                FormularioTemplatePlanoAulaFragment.newInstance(template.id).also {
+                    it.setListener(this)
+                    it.show(supportFragmentManager, FormularioTemplatePlanoAulaFragment.TAG)
+                }
+            },
+            onDeleteClickListener = { template ->
+                mostrarDialogoConfirmacaoDelete(template)
+            }
+        )
+        binding.recyclerViewTemplatesPlanoAula.apply {
+            adapter = templateAdapter
+            layoutManager = LinearLayoutManager(this@TemplatesPlanoAulaActivity)
+        }
+    }
+
+    private fun observeTemplates() {
+        lifecycleScope.launch {
+            templateDao.buscarTodos().collect { listaTemplates ->
+                templateAdapter.submitList(listaTemplates)
+                if (listaTemplates.isEmpty()) {
+                    binding.textViewListaVaziaTemplates.visibility = View.VISIBLE
+                    binding.recyclerViewTemplatesPlanoAula.visibility = View.GONE
+                } else {
+                    binding.textViewListaVaziaTemplates.visibility = View.GONE
+                    binding.recyclerViewTemplatesPlanoAula.visibility = View.VISIBLE
+                }
+            }
+        }
+    }
+
+    private fun mostrarDialogoConfirmacaoDelete(template: TemplatePlanoAula) {
+        AlertDialog.Builder(this)
+            .setTitle("Confirmar Exclusão")
+            .setMessage("Tem certeza que deseja excluir o template \"${template.nomeTemplate}\"?")
+            .setPositiveButton("Excluir") { _, _ ->
+                deletarTemplate(template)
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun deletarTemplate(template: TemplatePlanoAula) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            templateDao.deletar(template)
+            // A UI será atualizada automaticamente pelo Flow
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@TemplatesPlanoAulaActivity, "Template excluído.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onTemplateSalvo(template: TemplatePlanoAula) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            templateDao.inserir(template) // REPLACE strategy lida com insert/update
+             withContext(Dispatchers.Main) {
+                Toast.makeText(this@TemplatesPlanoAulaActivity, "Template salvo!", Toast.LENGTH_SHORT).show()
+            }
+            // A UI será atualizada automaticamente pelo Flow
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/AnotacaoAdapter.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/AnotacaoAdapter.kt
@@ -1,0 +1,99 @@
+package com.agendafocopei.ui.adapter
+
+import android.content.Context
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.lifecycle.findViewTreeLifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.data.Anotacao
+import com.agendafocopei.data.TurmaDao
+import com.agendafocopei.databinding.ListItemAnotacaoBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat
+import java.util.*
+
+class AnotacaoAdapter(
+    private val turmaDao: TurmaDao, // Passar o DAO para buscar nome da turma
+    private val onItemClickListener: (Anotacao) -> Unit,
+    private val onEditClickListener: (Anotacao) -> Unit,
+    private val onDeleteClickListener: (Anotacao) -> Unit
+) : ListAdapter<Anotacao, AnotacaoAdapter.AnotacaoViewHolder>(AnotacaoDiffCallback()) {
+
+    private val displayDateFormat = SimpleDateFormat("dd/MM/yy HH:mm", Locale("pt", "BR"))
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AnotacaoViewHolder {
+        val binding = ListItemAnotacaoBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return AnotacaoViewHolder(binding, turmaDao, displayDateFormat, onItemClickListener, onEditClickListener, onDeleteClickListener)
+    }
+
+    override fun onBindViewHolder(holder: AnotacaoViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class AnotacaoViewHolder(
+        private val binding: ListItemAnotacaoBinding,
+        private val turmaDao: TurmaDao,
+        private val dateFormatter: SimpleDateFormat,
+        private val onItemClick: (Anotacao) -> Unit,
+        private val onEditClick: (Anotacao) -> Unit,
+        private val onDeleteClick: (Anotacao) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(anotacao: Anotacao) {
+            binding.textViewConteudoAnotacaoItem.text = anotacao.conteudo
+            binding.textViewDataModificacaoAnotacaoItem.text = "Modif.: ${dateFormatter.format(Date(anotacao.dataModificacao))}"
+
+            binding.viewCorAnotacaoItem.setBackgroundColor(anotacao.cor ?: Color.TRANSPARENT)
+
+            if (!anotacao.tagsString.isNullOrEmpty()) {
+                binding.textViewTagsAnotacaoItem.text = "Tags: ${anotacao.tagsString}"
+                binding.textViewTagsAnotacaoItem.visibility = View.VISIBLE
+            } else {
+                binding.textViewTagsAnotacaoItem.visibility = View.GONE
+            }
+
+            // Associacao (Turma e Aluno)
+            var associacaoText = ""
+            if (anotacao.turmaId != null) {
+                // Busca nome da turma de forma assíncrona
+                itemView.findViewTreeLifecycleOwner()?.lifecycleScope?.launch {
+                    val turma = withContext(Dispatchers.IO) { turmaDao.buscarPorId(anotacao.turmaId!!) }
+                    associacaoText = "Turma: ${turma?.nome ?: "ID: "+anotacao.turmaId}"
+                    if (!anotacao.alunoNome.isNullOrEmpty()) {
+                        associacaoText += " (Aluno: ${anotacao.alunoNome})"
+                    }
+                    binding.textViewAssociacaoAnotacaoItem.text = associacaoText
+                    binding.textViewAssociacaoAnotacaoItem.visibility = View.VISIBLE
+                }
+            } else if (!anotacao.alunoNome.isNullOrEmpty()) {
+                associacaoText = "Aluno: ${anotacao.alunoNome}"
+                binding.textViewAssociacaoAnotacaoItem.text = associacaoText
+                binding.textViewAssociacaoAnotacaoItem.visibility = View.VISIBLE
+            } else {
+                binding.textViewAssociacaoAnotacaoItem.visibility = View.GONE
+            }
+
+
+            binding.buttonEditarAnotacaoItem.setOnClickListener { onEditClick(anotacao) }
+            binding.buttonDeletarAnotacaoItem.setOnClickListener { onDeleteClick(anotacao) }
+            itemView.setOnClickListener { onItemClick(anotacao) }
+        }
+    }
+
+    class AnotacaoDiffCallback : DiffUtil.ItemCallback<Anotacao>() {
+        override fun areItemsTheSame(oldItem: Anotacao, newItem: Anotacao): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: Anotacao, newItem: Anotacao): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/GuiaDeAprendizagemAdapter.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/GuiaDeAprendizagemAdapter.kt
@@ -1,0 +1,65 @@
+package com.agendafocopei.ui.adapter
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.databinding.ListItemGuiaDeAprendizagemBinding
+import com.agendafocopei.ui.model.GuiaDeAprendizagemDisplay
+
+class GuiaDeAprendizagemAdapter(
+    private val onDetalhesClickListener: (GuiaDeAprendizagemDisplay) -> Unit,
+    private val onEditClickListener: (GuiaDeAprendizagemDisplay) -> Unit,
+    private val onDeleteClickListener: (GuiaDeAprendizagemDisplay) -> Unit
+) : ListAdapter<GuiaDeAprendizagemDisplay, GuiaDeAprendizagemAdapter.GuiaViewHolder>(GuiaDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): GuiaViewHolder {
+        val binding = ListItemGuiaDeAprendizagemBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return GuiaViewHolder(binding, onDetalhesClickListener, onEditClickListener, onDeleteClickListener)
+    }
+
+    override fun onBindViewHolder(holder: GuiaViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class GuiaViewHolder(
+        private val binding: ListItemGuiaDeAprendizagemBinding,
+        private val onDetalhes: (GuiaDeAprendizagemDisplay) -> Unit,
+        private val onEdit: (GuiaDeAprendizagemDisplay) -> Unit,
+        private val onDelete: (GuiaDeAprendizagemDisplay) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(guiaDisplay: GuiaDeAprendizagemDisplay) {
+            val guia = guiaDisplay.guiaDeAprendizagem
+
+            val tituloGerado = "Guia: ${guiaDisplay.nomeDisciplina ?: ""} - ${guia.bimestre} ${guia.ano}"
+            binding.textViewTituloGuiaItem.text = guia.tituloGuia ?: tituloGerado
+
+            // Placeholder para progresso - a ser implementado com contagem de itens do checklist
+            binding.textViewProgressoChecklistGuia.text = "Checklist: (N/A)"
+
+            binding.imageViewAnexoIconGuia.visibility = if (guia.caminhoAnexoGuia != null) View.VISIBLE else View.GONE
+            binding.viewCorGuia.setBackgroundColor(guiaDisplay.corDisciplina ?: Color.LTGRAY)
+
+            binding.buttonDetalhesGuia.setOnClickListener { onDetalhes(guiaDisplay) }
+            binding.buttonEditarGuia.setOnClickListener { onEdit(guiaDisplay) }
+            binding.buttonDeletarGuia.setOnClickListener { onDelete(guiaDisplay) }
+
+            // Clique no item inteiro também pode levar aos detalhes
+            itemView.setOnClickListener { onDetalhes(guiaDisplay) }
+        }
+    }
+
+    class GuiaDiffCallback : DiffUtil.ItemCallback<GuiaDeAprendizagemDisplay>() {
+        override fun areItemsTheSame(oldItem: GuiaDeAprendizagemDisplay, newItem: GuiaDeAprendizagemDisplay): Boolean {
+            return oldItem.guiaDeAprendizagem.id == newItem.guiaDeAprendizagem.id
+        }
+
+        override fun areContentsTheSame(oldItem: GuiaDeAprendizagemDisplay, newItem: GuiaDeAprendizagemDisplay): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/ItemChecklistGuiaAdapter.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/ItemChecklistGuiaAdapter.kt
@@ -1,0 +1,56 @@
+package com.agendafocopei.ui.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.data.ItemChecklistGuia
+import com.agendafocopei.databinding.ListItemChecklistGuiaBinding
+
+class ItemChecklistGuiaAdapter(
+    private val onItemCheckChanged: (ItemChecklistGuia, Boolean) -> Unit,
+    private val onDeleteItemClickListener: (ItemChecklistGuia) -> Unit
+) : ListAdapter<ItemChecklistGuia, ItemChecklistGuiaAdapter.ItemChecklistGuiaViewHolder>(ItemChecklistDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ItemChecklistGuiaViewHolder {
+        val binding = ListItemChecklistGuiaBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ItemChecklistGuiaViewHolder(binding, onItemCheckChanged, onDeleteItemClickListener)
+    }
+
+    override fun onBindViewHolder(holder: ItemChecklistGuiaViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ItemChecklistGuiaViewHolder(
+        private val binding: ListItemChecklistGuiaBinding,
+        private val onCheckChanged: (ItemChecklistGuia, Boolean) -> Unit,
+        private val onDeleteClick: (ItemChecklistGuia) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(item: ItemChecklistGuia) {
+            binding.textViewDescricaoItemChecklist.text = item.descricaoItem
+
+            // Remove listener temporariamente para evitar trigger ao setar o estado inicial
+            binding.checkBoxItemChecklist.setOnCheckedChangeListener(null)
+            binding.checkBoxItemChecklist.isChecked = item.concluido
+            binding.checkBoxItemChecklist.setOnCheckedChangeListener { _, isChecked ->
+                onCheckChanged(item, isChecked)
+            }
+
+            binding.buttonDeletarItemChecklist.setOnClickListener {
+                onDeleteClick(item)
+            }
+        }
+    }
+
+    class ItemChecklistDiffCallback : DiffUtil.ItemCallback<ItemChecklistGuia>() {
+        override fun areItemsTheSame(oldItem: ItemChecklistGuia, newItem: ItemChecklistGuia): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: ItemChecklistGuia, newItem: ItemChecklistGuia): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/PlanoDeAulaAdapter.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/PlanoDeAulaAdapter.kt
@@ -1,0 +1,88 @@
+package com.agendafocopei.ui.adapter
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.databinding.ListItemPlanoDeAulaBinding
+import com.agendafocopei.ui.model.PlanoDeAulaDisplay
+import java.text.SimpleDateFormat
+import java.util.*
+
+class PlanoDeAulaAdapter(
+    private val onEditClickListener: (PlanoDeAulaDisplay) -> Unit,
+    private val onDeleteClickListener: (PlanoDeAulaDisplay) -> Unit,
+    private val onItemClickListener: (PlanoDeAulaDisplay) -> Unit
+) : ListAdapter<PlanoDeAulaDisplay, PlanoDeAulaAdapter.PlanoViewHolder>(PlanoDiffCallback()) {
+
+    private val displayDateFormat = SimpleDateFormat("dd/MM/yyyy", Locale("pt", "BR"))
+    private val storedDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PlanoViewHolder {
+        val binding = ListItemPlanoDeAulaBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return PlanoViewHolder(binding, onEditClickListener, onDeleteClickListener, onItemClickListener)
+    }
+
+    override fun onBindViewHolder(holder: PlanoViewHolder, position: Int) {
+        holder.bind(getItem(position), displayDateFormat, storedDateFormat)
+    }
+
+    class PlanoViewHolder(
+        private val binding: ListItemPlanoDeAulaBinding,
+        private val onEdit: (PlanoDeAulaDisplay) -> Unit,
+        private val onDelete: (PlanoDeAulaDisplay) -> Unit,
+        private val onItemClick: (PlanoDeAulaDisplay) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(planoDisplay: PlanoDeAulaDisplay, displayFormatter: SimpleDateFormat, storedFormatter: SimpleDateFormat) {
+            val plano = planoDisplay.planoDeAula
+
+            binding.textViewTituloPlanoItem.text = plano.tituloPlano ?: "Plano para ${planoDisplay.nomeDisciplina ?: "Disciplina"}"
+
+            if (plano.dataAula != null) {
+                try {
+                    val date = storedFormatter.parse(plano.dataAula)
+                    binding.textViewDataPlanoItem.text = "Data: ${date?.let { displayFormatter.format(it) } ?: "N/A"}"
+                    binding.textViewDataPlanoItem.visibility = View.VISIBLE
+                } catch (e: Exception) {
+                    binding.textViewDataPlanoItem.text = "Data: ${plano.dataAula}" // Formato original se falhar
+                    binding.textViewDataPlanoItem.visibility = View.VISIBLE
+                }
+            } else {
+                binding.textViewDataPlanoItem.visibility = View.GONE
+            }
+
+            binding.textViewDisciplinaPlanoItem.text = "Disciplina: ${planoDisplay.nomeDisciplina ?: "Não especificada"}"
+
+            if (planoDisplay.nomeTurma != null) {
+                binding.textViewTurmaPlanoItem.text = "Turma: ${planoDisplay.nomeTurma}"
+                binding.textViewTurmaPlanoItem.visibility = View.VISIBLE
+            } else {
+                binding.textViewTurmaPlanoItem.visibility = View.GONE
+            }
+
+            binding.imageViewAnexoIconPlanoItem.visibility = if (plano.caminhoAnexo != null) View.VISIBLE else View.GONE
+
+            // Usar cor da disciplina como indicador
+            binding.viewCorIndicadorPlano.setBackgroundColor(planoDisplay.corDisciplina ?: Color.LTGRAY)
+
+            binding.buttonEditarPlano.setOnClickListener { onEdit(planoDisplay) }
+            binding.buttonDeletarPlano.setOnClickListener { onDelete(planoDisplay) }
+            itemView.setOnClickListener { onItemClick(planoDisplay) }
+        }
+    }
+
+    class PlanoDiffCallback : DiffUtil.ItemCallback<PlanoDeAulaDisplay>() {
+        override fun areItemsTheSame(oldItem: PlanoDeAulaDisplay, newItem: PlanoDeAulaDisplay): Boolean {
+            return oldItem.planoDeAula.id == newItem.planoDeAula.id
+        }
+
+        override fun areContentsTheSame(oldItem: PlanoDeAulaDisplay, newItem: PlanoDeAulaDisplay): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/SubtarefaAdapter.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/SubtarefaAdapter.kt
@@ -1,0 +1,93 @@
+package com.agendafocopei.ui.adapter
+
+import android.text.Editable
+import android.text.TextWatcher
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.data.Subtarefa
+import com.agendafocopei.databinding.ListItemSubtarefaBinding
+
+class SubtarefaAdapter(
+    private val onItemCheckedChange: (Subtarefa, Boolean) -> Unit,
+    private val onItemDescriptionChange: (Subtarefa, String) -> Unit,
+    private val onDeleteClickListener: (Subtarefa) -> Unit
+) : ListAdapter<Subtarefa, SubtarefaAdapter.SubtarefaViewHolder>(SubtarefaDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SubtarefaViewHolder {
+        val binding = ListItemSubtarefaBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return SubtarefaViewHolder(binding, onItemCheckedChange, onItemDescriptionChange, onDeleteClickListener)
+    }
+
+    override fun onBindViewHolder(holder: SubtarefaViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    // Limpa os listeners para evitar que o TextWatcher antigo atue em um ViewHolder reutilizado
+    override fun onViewRecycled(holder: SubtarefaViewHolder) {
+        super.onViewRecycled(holder)
+        holder.clearListeners()
+    }
+
+
+    class SubtarefaViewHolder(
+        private val binding: ListItemSubtarefaBinding,
+        private val onCheckChanged: (Subtarefa, Boolean) -> Unit,
+        private val onDescriptionChange: (Subtarefa, String) -> Unit,
+        private val onDeleteClick: (Subtarefa) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        private var currentSubtarefa: Subtarefa? = null
+        private val textWatcher = object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {}
+            override fun afterTextChanged(s: Editable?) {
+                currentSubtarefa?.let {
+                    // Evita loop infinito e atualiza apenas se o texto realmente mudou
+                    if (it.descricaoSubtarefa != s.toString()) {
+                        onDescriptionChange(it, s.toString())
+                    }
+                }
+            }
+        }
+
+        fun bind(subtarefa: Subtarefa) {
+            currentSubtarefa = subtarefa
+            binding.editTextDescricaoSubtarefaItem.setText(subtarefa.descricaoSubtarefa)
+            binding.checkBoxSubtarefaConcluida.isChecked = subtarefa.concluida
+
+            // É crucial remover o listener antigo antes de adicionar um novo ou setar o estado do checkbox
+            binding.checkBoxSubtarefaConcluida.setOnCheckedChangeListener(null)
+            binding.checkBoxSubtarefaConcluida.isChecked = subtarefa.concluida
+            binding.checkBoxSubtarefaConcluida.setOnCheckedChangeListener { _, isChecked ->
+                currentSubtarefa?.let { onCheckChanged(it, isChecked) }
+            }
+
+            binding.editTextDescricaoSubtarefaItem.removeTextChangedListener(textWatcher) // Remove antes para evitar múltiplos listeners
+            binding.editTextDescricaoSubtarefaItem.setText(subtarefa.descricaoSubtarefa)
+            binding.editTextDescricaoSubtarefaItem.addTextChangedListener(textWatcher)
+
+
+            binding.buttonDeletarSubtarefa.setOnClickListener {
+                currentSubtarefa?.let { onDeleteClick(it) }
+            }
+        }
+
+        fun clearListeners() {
+            binding.editTextDescricaoSubtarefaItem.removeTextChangedListener(textWatcher)
+            binding.checkBoxSubtarefaConcluida.setOnCheckedChangeListener(null)
+        }
+    }
+
+    class SubtarefaDiffCallback : DiffUtil.ItemCallback<Subtarefa>() {
+        override fun areItemsTheSame(oldItem: Subtarefa, newItem: Subtarefa): Boolean {
+            return oldItem.id == newItem.id && oldItem.tarefaId == newItem.tarefaId // Considerar tarefaId se id for 0 para novos
+        }
+
+        override fun areContentsTheSame(oldItem: Subtarefa, newItem: Subtarefa): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/TarefaAdapter.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/TarefaAdapter.kt
@@ -1,0 +1,128 @@
+package com.agendafocopei.ui.adapter
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.Paint
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.R
+import com.agendafocopei.data.Tarefa
+import com.agendafocopei.databinding.ListItemTarefaBinding
+import com.agendafocopei.ui.model.TarefaDisplay
+import java.text.SimpleDateFormat
+import java.util.*
+
+class TarefaAdapter(
+    private val onTarefaCheckChanged: (TarefaDisplay, Boolean) -> Unit,
+    private val onEditClickListener: (TarefaDisplay) -> Unit
+) : ListAdapter<TarefaDisplay, TarefaAdapter.TarefaViewHolder>(TarefaDiffCallback()) {
+
+    private val displayPrazoFormat = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale("pt", "BR"))
+    private val storedPrazoDataFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TarefaViewHolder {
+        val binding = ListItemTarefaBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return TarefaViewHolder(binding, onTarefaCheckChanged, onEditClickListener, displayPrazoFormat, storedPrazoDataFormat)
+    }
+
+    override fun onBindViewHolder(holder: TarefaViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class TarefaViewHolder(
+        private val binding: ListItemTarefaBinding,
+        private val onCheckChanged: (TarefaDisplay, Boolean) -> Unit,
+        private val onEditClick: (TarefaDisplay) -> Unit,
+        private val displayPrazoFormatter: SimpleDateFormat,
+        private val storedPrazoDataFormatter: SimpleDateFormat
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        private val context: Context = itemView.context
+
+        fun bind(tarefaDisplay: TarefaDisplay) {
+            val tarefa = tarefaDisplay.tarefa
+            binding.textViewTarefaDescricao.text = tarefa.descricao
+
+            // Checkbox
+            binding.checkBoxTarefaConcluida.setOnCheckedChangeListener(null) // Evitar trigger no bind
+            binding.checkBoxTarefaConcluida.isChecked = tarefa.concluida
+            binding.checkBoxTarefaConcluida.setOnCheckedChangeListener { _, isChecked ->
+                onCheckChanged(tarefaDisplay, isChecked)
+            }
+
+            // Strikethrough
+            if (tarefa.concluida) {
+                binding.textViewTarefaDescricao.paintFlags = binding.textViewTarefaDescricao.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG
+            } else {
+                binding.textViewTarefaDescricao.paintFlags = binding.textViewTarefaDescricao.paintFlags and Paint.STRIKE_THRU_TEXT_FLAG.inv()
+            }
+
+            // Prioridade
+            when (tarefa.prioridade) {
+                0 -> binding.viewPrioridadeTarefa.setBackgroundColor(ContextCompat.getColor(context, R.color.prioridade_baixa)) // Definir cores em colors.xml
+                1 -> binding.viewPrioridadeTarefa.setBackgroundColor(ContextCompat.getColor(context, R.color.prioridade_media))
+                2 -> binding.viewPrioridadeTarefa.setBackgroundColor(ContextCompat.getColor(context, R.color.prioridade_alta))
+                else -> binding.viewPrioridadeTarefa.setBackgroundColor(Color.TRANSPARENT)
+            }
+
+            // Prazo
+            if (tarefa.prazoData != null) {
+                var prazoStr = ""
+                try {
+                    val date = storedPrazoDataFormatter.parse(tarefa.prazoData!!)
+                    prazoStr = SimpleDateFormat("dd/MM/yy", Locale("pt","BR")).format(date!!)
+                } catch (e: Exception) {
+                    prazoStr = tarefa.prazoData!! // fallback
+                }
+
+                if (tarefa.prazoHora != null) {
+                    prazoStr += " ${tarefa.prazoHora}"
+                }
+                binding.textViewTarefaPrazo.text = "Prazo: $prazoStr"
+                binding.textViewTarefaPrazo.visibility = View.VISIBLE
+            } else {
+                binding.textViewTarefaPrazo.visibility = View.GONE
+            }
+
+            // Chip Disciplina
+            if (tarefaDisplay.nomeDisciplina != null) {
+                binding.chipDisciplinaTarefa.text = tarefaDisplay.nomeDisciplina
+                binding.chipDisciplinaTarefa.chipBackgroundColor = ColorStateList.valueOf(tarefaDisplay.corDisciplina ?: Color.LTGRAY)
+                binding.chipDisciplinaTarefa.visibility = View.VISIBLE
+            } else {
+                binding.chipDisciplinaTarefa.visibility = View.GONE
+            }
+
+            // Chip Turma
+            if (tarefaDisplay.nomeTurma != null) {
+                binding.chipTurmaTarefa.text = tarefaDisplay.nomeTurma
+                binding.chipTurmaTarefa.chipBackgroundColor = ColorStateList.valueOf(tarefaDisplay.corTurma ?: Color.LTGRAY)
+                binding.chipTurmaTarefa.visibility = View.VISIBLE
+            } else {
+                binding.chipTurmaTarefa.visibility = View.GONE
+            }
+
+            binding.chipGroupAssociacoesTarefa.visibility =
+                if(binding.chipDisciplinaTarefa.visibility == View.VISIBLE || binding.chipTurmaTarefa.visibility == View.VISIBLE) View.VISIBLE else View.GONE
+
+
+            binding.buttonEditarTarefaItem.setOnClickListener { onEditClick(tarefaDisplay) }
+        }
+    }
+
+    class TarefaDiffCallback : DiffUtil.ItemCallback<TarefaDisplay>() {
+        override fun areItemsTheSame(oldItem: TarefaDisplay, newItem: TarefaDisplay): Boolean {
+            return oldItem.tarefa.id == newItem.tarefa.id
+        }
+
+        override fun areContentsTheSame(oldItem: TarefaDisplay, newItem: TarefaDisplay): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/TemplatePlanoAulaAdapter.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/adapter/TemplatePlanoAulaAdapter.kt
@@ -1,0 +1,49 @@
+package com.agendafocopei.ui.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.data.TemplatePlanoAula
+import com.agendafocopei.databinding.ListItemTemplatePlanoAulaBinding
+
+class TemplatePlanoAulaAdapter(
+    private val onEditClickListener: (TemplatePlanoAula) -> Unit,
+    private val onDeleteClickListener: (TemplatePlanoAula) -> Unit
+) : ListAdapter<TemplatePlanoAula, TemplatePlanoAulaAdapter.TemplateViewHolder>(TemplateDiffCallback()) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TemplateViewHolder {
+        val binding = ListItemTemplatePlanoAulaBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return TemplateViewHolder(binding, onEditClickListener, onDeleteClickListener)
+    }
+
+    override fun onBindViewHolder(holder: TemplateViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class TemplateViewHolder(
+        private val binding: ListItemTemplatePlanoAulaBinding,
+        private val onEdit: (TemplatePlanoAula) -> Unit,
+        private val onDelete: (TemplatePlanoAula) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(template: TemplatePlanoAula) {
+            binding.textViewNomeTemplateItem.text = template.nomeTemplate
+            binding.buttonEditarTemplate.setOnClickListener { onEdit(template) }
+            binding.buttonDeletarTemplate.setOnClickListener { onDelete(template) }
+            // Adicionar um listener ao itemView se quiser que o clique no item faça algo (ex: preview)
+            // itemView.setOnClickListener { /* ... */ }
+        }
+    }
+
+    class TemplateDiffCallback : DiffUtil.ItemCallback<TemplatePlanoAula>() {
+        override fun areItemsTheSame(oldItem: TemplatePlanoAula, newItem: TemplatePlanoAula): Boolean {
+            return oldItem.id == newItem.id
+        }
+
+        override fun areContentsTheSame(oldItem: TemplatePlanoAula, newItem: TemplatePlanoAula): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioAnotacaoFragment.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioAnotacaoFragment.kt
@@ -1,0 +1,213 @@
+package com.agendafocopei.ui.dialog
+
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import com.agendafocopei.data.Anotacao
+import com.agendafocopei.data.AnotacaoDao
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.Turma
+import com.agendafocopei.data.TurmaDao
+import com.agendafocopei.databinding.DialogFormularioAnotacaoBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.*
+
+class FormularioAnotacaoFragment : DialogFragment(), ColorPickerDialogFragment.ColorPickerListener {
+
+    private var _binding: DialogFormularioAnotacaoBinding? = null
+    private val binding get() = _binding!!
+
+    interface FormularioAnotacaoListener {
+        fun onAnotacaoSalva(anotacao: Anotacao)
+    }
+
+    private var listener: FormularioAnotacaoListener? = null
+    private var anotacaoIdParaEdicao: Int? = null
+    private var anotacaoParaEdicao: Anotacao? = null
+
+    private lateinit var anotacaoDao: AnotacaoDao
+    private lateinit var turmaDao: TurmaDao
+
+    private var listaTurmas: List<Turma> = emptyList()
+    private var corSelecionadaAnotacao: Int? = null
+
+    companion object {
+        const val TAG = "FormularioAnotacaoDialog"
+        private const val ARG_ANOTACAO_ID = "arg_anotacao_id"
+        private const val COLOR_PICKER_REQUEST_TAG = "anotacao_color_picker"
+
+        fun newInstance(anotacaoId: Int? = null): FormularioAnotacaoFragment {
+            val fragment = FormularioAnotacaoFragment()
+            val args = Bundle()
+            anotacaoId?.let { args.putInt(ARG_ANOTACAO_ID, it) }
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            if (it.containsKey(ARG_ANOTACAO_ID)) {
+                anotacaoIdParaEdicao = it.getInt(ARG_ANOTACAO_ID)
+            }
+        }
+        val db = AppDatabase.getDatabase(requireContext())
+        anotacaoDao = db.anotacaoDao()
+        turmaDao = db.turmaDao()
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogFormularioAnotacaoBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupTurmaSpinner()
+        setupColorPicker()
+        setupGravarVozButton()
+
+        if (anotacaoIdParaEdicao != null) {
+            binding.textViewFormularioAnotacaoTitulo.text = "Editar Anotação"
+            carregarAnotacaoParaEdicao(anotacaoIdParaEdicao!!)
+        } else {
+            binding.textViewFormularioAnotacaoTitulo.text = "Nova Anotação"
+            updateColorPreview() // Para cor inicial transparente
+        }
+
+        binding.buttonSalvarAnotacao.setOnClickListener { salvarAnotacao() }
+        binding.buttonCancelarAnotacao.setOnClickListener { dismiss() }
+    }
+
+    private fun setupTurmaSpinner() {
+        lifecycleScope.launch {
+            listaTurmas = withContext(Dispatchers.IO) { turmaDao.buscarTodas().first() }
+            val nomesTurmasComOpcao = listOf("Nenhuma (Geral/Pessoal)") + listaTurmas.map { it.nome }
+            val turmaAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesTurmasComOpcao).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerTurmaAnotacao.adapter = turmaAdapter
+            binding.spinnerTurmaAnotacao.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                    // Mostrar/ocultar campo de aluno se "Nenhuma" for selecionada ou não.
+                    // Aqui, a lógica é que o campo Aluno é sempre visível se uma turma é selecionada,
+                    // mas poderia ser oculto se "Nenhuma" for selecionada.
+                    // Por enquanto, mantendo simples: campo Aluno é sempre editável.
+                }
+                override fun onNothingSelected(parent: AdapterView<*>?) {}
+            }
+
+            // Se estiver editando, selecionar valor após carregar
+            if (anotacaoIdParaEdicao != null && anotacaoParaEdicao != null) {
+                selecionarValoresSpinnerEdicao(anotacaoParaEdicao!!)
+            }
+        }
+    }
+
+    private fun setupColorPicker() {
+        binding.buttonEscolherCorAnotacao.setOnClickListener {
+            val dialog = ColorPickerDialogFragment.newInstance(corSelecionadaAnotacao, COLOR_PICKER_REQUEST_TAG)
+            dialog.show(childFragmentManager, ColorPickerDialogFragment.TAG)
+        }
+        binding.viewPreviewCorAnotacao.setOnClickListener { // Também abre o picker
+             binding.buttonEscolherCorAnotacao.performClick()
+        }
+    }
+
+    private fun setupGravarVozButton() {
+        binding.buttonGravarVozAnotacao.setOnClickListener {
+            Toast.makeText(context, "Funcionalidade de Gravar Voz em breve!", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun updateColorPreview() {
+        binding.viewPreviewCorAnotacao.setBackgroundColor(corSelecionadaAnotacao ?: Color.TRANSPARENT)
+    }
+
+    private fun carregarAnotacaoParaEdicao(id: Int) {
+        lifecycleScope.launch {
+            anotacaoParaEdicao = withContext(Dispatchers.IO) { anotacaoDao.buscarPorId(id) }
+            anotacaoParaEdicao?.let { anotacao ->
+                binding.editTextConteudoAnotacao.setText(anotacao.conteudo)
+                binding.editTextTagsAnotacao.setText(anotacao.tagsString)
+                corSelecionadaAnotacao = anotacao.cor
+                updateColorPreview()
+                binding.editTextAlunoAnotacao.setText(anotacao.alunoNome)
+
+                if(listaTurmas.isNotEmpty()){ // Garante que o spinner já foi populado
+                     selecionarValoresSpinnerEdicao(anotacao)
+                }
+            }
+        }
+    }
+
+    private fun selecionarValoresSpinnerEdicao(anotacao: Anotacao) {
+        val turmaPos = anotacao.turmaId?.let { turId -> listaTurmas.indexOfFirst { it.id == turId } } ?: -1
+        binding.spinnerTurmaAnotacao.setSelection(if (turmaPos != -1) turmaPos + 1 else 0) // +1 por "Nenhuma"
+    }
+
+    private fun salvarAnotacao() {
+        val conteudo = binding.editTextConteudoAnotacao.text.toString().trim()
+        if (conteudo.isEmpty()) {
+            binding.editTextConteudoAnotacao.error = "Conteúdo é obrigatório"
+            return
+        } else {
+            binding.editTextConteudoAnotacao.error = null
+        }
+
+        val tags = binding.editTextTagsAnotacao.text.toString().trim()
+        val alunoNome = binding.editTextAlunoAnotacao.text.toString().trim()
+
+        val turmaIdSelecionada: Int? = if (binding.spinnerTurmaAnotacao.selectedItemPosition > 0 && listaTurmas.isNotEmpty()) {
+            listaTurmas[binding.spinnerTurmaAnotacao.selectedItemPosition - 1].id
+        } else null
+
+
+        val anotacaoParaSalvar = Anotacao(
+            id = anotacaoIdParaEdicao ?: 0,
+            conteudo = conteudo,
+            dataCriacao = anotacaoParaEdicao?.dataCriacao ?: System.currentTimeMillis(),
+            dataModificacao = System.currentTimeMillis(),
+            cor = corSelecionadaAnotacao,
+            turmaId = turmaIdSelecionada,
+            alunoNome = alunoNome.ifEmpty { null },
+            tagsString = tags.ifEmpty { null }
+        )
+
+        listener?.onAnotacaoSalva(anotacaoParaSalvar)
+        dismiss()
+    }
+
+    override fun onColorSelected(color: Int, tag: String?) {
+        if (tag == COLOR_PICKER_REQUEST_TAG) {
+            corSelecionadaAnotacao = color
+            updateColorPreview()
+        }
+    }
+
+    fun setListener(listener: FormularioAnotacaoListener) {
+        this.listener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioGuiaFragment.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioGuiaFragment.kt
@@ -1,0 +1,218 @@
+package com.agendafocopei.ui.dialog
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.OpenableColumns
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.Disciplina
+import com.agendafocopei.data.DisciplinaDao
+import com.agendafocopei.data.GuiaDeAprendizagem
+import com.agendafocopei.data.GuiaDeAprendizagemDao
+import com.agendafocopei.databinding.DialogFormularioGuiaBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.*
+
+class FormularioGuiaFragment : DialogFragment() {
+
+    private var _binding: DialogFormularioGuiaBinding? = null
+    private val binding get() = _binding!!
+
+    interface FormularioGuiaListener {
+        fun onGuiaSalvo(guia: GuiaDeAprendizagem)
+    }
+
+    private var listener: FormularioGuiaListener? = null
+    private var guiaIdParaEdicao: Int? = null
+
+    private lateinit var guiaDao: GuiaDeAprendizagemDao
+    private lateinit var disciplinaDao: DisciplinaDao
+
+    private var listaDisciplinas: List<Disciplina> = emptyList()
+
+    private var anexoUri: Uri? = null
+    private var anexoNome: String? = null
+    private var anexoTipo: String? = null
+
+    private lateinit var anexoLauncher: ActivityResultLauncher<Intent>
+
+    companion object {
+        const val TAG = "FormularioGuiaDialog"
+        private const val ARG_GUIA_ID = "arg_guia_id"
+
+        fun newInstance(guiaId: Int? = null): FormularioGuiaFragment {
+            val fragment = FormularioGuiaFragment()
+            val args = Bundle()
+            guiaId?.let { args.putInt(ARG_GUIA_ID, it) }
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            if (it.containsKey(ARG_GUIA_ID)) {
+                guiaIdParaEdicao = it.getInt(ARG_GUIA_ID)
+            }
+        }
+
+        val db = AppDatabase.getDatabase(requireContext())
+        guiaDao = db.guiaDeAprendizagemDao()
+        disciplinaDao = db.disciplinaDao()
+
+        anexoLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.data?.let { uri ->
+                    anexoUri = uri
+                    anexoTipo = requireContext().contentResolver.getType(uri)
+                    val cursor = requireContext().contentResolver.query(uri, null, null, null, null)
+                    cursor?.use {
+                        if (it.moveToFirst()) {
+                            val nameIndex = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                            if (nameIndex != -1) anexoNome = it.getString(nameIndex)
+                        }
+                    }
+                    binding.textViewNomeAnexoGuia.text = anexoNome ?: uri.lastPathSegment ?: "Arquivo selecionado"
+                }
+            }
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogFormularioGuiaBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupSpinners()
+        setupAnexoButton()
+
+        if (guiaIdParaEdicao != null) {
+            binding.textViewFormularioGuiaTitulo.text = "Editar Guia de Aprendizagem"
+            carregarGuiaParaEdicao(guiaIdParaEdicao!!)
+        } else {
+            binding.textViewFormularioGuiaTitulo.text = "Novo Guia de Aprendizagem"
+            // Preencher ano atual por padrão
+            binding.editTextAnoGuia.setText(Calendar.getInstance().get(Calendar.YEAR).toString())
+        }
+
+        binding.buttonSalvarGuia.setOnClickListener { salvarGuia() }
+        binding.buttonCancelarGuia.setOnClickListener { dismiss() }
+    }
+
+    private fun setupSpinners() {
+        lifecycleScope.launch {
+            listaDisciplinas = withContext(Dispatchers.IO) { disciplinaDao.buscarTodas().first() }
+            val nomesDisciplinas = listaDisciplinas.map { it.nome }
+            val disciplinaAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesDisciplinas).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerDisciplinaGuia.adapter = disciplinaAdapter
+
+            // Se estiver editando, recarregar para garantir que o spinner é selecionado após ser populado
+            if (guiaIdParaEdicao != null && _binding != null) {
+                 carregarGuiaParaEdicao(guiaIdParaEdicao!!, true)
+            }
+        }
+    }
+
+    private fun setupAnexoButton() {
+        binding.buttonAnexarDocumentoGuia.setOnClickListener {
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "*/*" // Todos os tipos
+            }
+            anexoLauncher.launch(intent)
+        }
+    }
+
+    private fun carregarGuiaParaEdicao(id: Int, apenasSelecionarSpinners: Boolean = false) {
+        lifecycleScope.launch {
+            val guia = withContext(Dispatchers.IO) { guiaDao.buscarPorId(id) }
+            guia?.let {
+                if (!apenasSelecionarSpinners && _binding != null) {
+                    binding.editTextTituloGuiaForm.setText(it.tituloGuia)
+                    binding.editTextBimestreGuia.setText(it.bimestre)
+                    binding.editTextAnoGuia.setText(it.ano.toString())
+                    anexoUri = it.caminhoAnexoGuia?.let { Uri.parse(it) }
+                    anexoTipo = it.tipoAnexoGuia
+                    binding.textViewNomeAnexoGuia.text = anexoUri?.lastPathSegment ?: "Nenhum anexo" // Simplificado
+                }
+
+                if (listaDisciplinas.isNotEmpty()) {
+                    val discPos = listaDisciplinas.indexOfFirst { d -> d.id == it.disciplinaId }
+                    if (discPos != -1) binding.spinnerDisciplinaGuia.setSelection(discPos)
+                }
+            }
+        }
+    }
+
+    private fun salvarGuia() {
+        val titulo = binding.editTextTituloGuiaForm.text.toString().trim()
+        val bimestre = binding.editTextBimestreGuia.text.toString().trim()
+        val anoStr = binding.editTextAnoGuia.text.toString().trim()
+
+        if (binding.spinnerDisciplinaGuia.selectedItemPosition < 0 || listaDisciplinas.isEmpty()) {
+            Toast.makeText(context, "Selecione uma disciplina.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val disciplinaSelecionada = listaDisciplinas[binding.spinnerDisciplinaGuia.selectedItemPosition]
+
+        if (bimestre.isEmpty()) {
+            binding.editTextBimestreGuia.error = "Bimestre é obrigatório."
+            return
+        } else {
+            binding.editTextBimestreGuia.error = null
+        }
+
+        val ano = anoStr.toIntOrNull()
+        if (ano == null || ano < 2000 || ano > 2100) {
+            binding.editTextAnoGuia.error = "Ano inválido."
+            return
+        } else {
+            binding.editTextAnoGuia.error = null
+        }
+
+        val guiaParaSalvar = GuiaDeAprendizagem(
+            id = guiaIdParaEdicao ?: 0,
+            tituloGuia = titulo.ifEmpty { null },
+            disciplinaId = disciplinaSelecionada.id,
+            bimestre = bimestre,
+            ano = ano,
+            caminhoAnexoGuia = anexoUri?.toString(),
+            tipoAnexoGuia = anexoTipo
+        )
+        listener?.onGuiaSalvo(guiaParaSalvar)
+        dismiss()
+    }
+
+    fun setListener(listener: FormularioGuiaListener) {
+        this.listener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioPlanoDeAulaFragment.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioPlanoDeAulaFragment.kt
@@ -1,0 +1,364 @@
+package com.agendafocopei.ui.dialog
+
+import android.app.Activity
+import android.app.DatePickerDialog
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.provider.OpenableColumns
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView // Import para AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import com.agendafocopei.data.*
+import com.agendafocopei.databinding.DialogFormularioPlanoDeAulaBinding
+import com.google.android.material.textfield.TextInputEditText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.*
+
+class FormularioPlanoDeAulaFragment : DialogFragment() {
+
+    private var _binding: DialogFormularioPlanoDeAulaBinding? = null
+    private val binding get() = _binding!!
+
+    interface FormularioPlanoListener {
+        fun onPlanoSalvo(plano: PlanoDeAula)
+    }
+
+    private var listener: FormularioPlanoListener? = null
+    private var planoIdParaEdicao: Int? = null
+    private var horarioAulaIdPredefinido: Int? = null
+    private var disciplinaIdPredefinida: Int? = null
+    private var turmaIdPredefinida: Int? = null
+    private var dataPredefinida: String? = null // YYYY-MM-DD
+
+    private lateinit var planoDeAulaDao: PlanoDeAulaDao
+    private lateinit var disciplinaDao: DisciplinaDao
+    private lateinit var turmaDao: TurmaDao
+    private lateinit var templateDao: TemplatePlanoAulaDao // Agora usado
+
+    private var listaDisciplinas: List<Disciplina> = emptyList()
+    private var listaTurmas: List<Turma> = emptyList()
+    private var templatesDisponiveis: List<TemplatePlanoAula> = emptyList() // Agora usado
+
+    private var dataAulaSelecionada: Calendar? = null
+    private val displayDateFormat = SimpleDateFormat("dd/MM/yyyy", Locale("pt", "BR"))
+    private val storeDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+    private var anexoUri: Uri? = null
+    private var anexoNome: String? = null
+    private var anexoTipo: String? = null
+
+    private lateinit var anexoLauncher: ActivityResultLauncher<Intent>
+
+    companion object {
+        const val TAG = "FormularioPlanoDeAulaDialog"
+        private const val ARG_PLANO_ID = "arg_plano_id"
+        private const val ARG_HORARIO_AULA_ID = "arg_horario_aula_id"
+        private const val ARG_DISCIPLINA_ID_PREDEF = "arg_disciplina_id_predef"
+        private const val ARG_TURMA_ID_PREDEF = "arg_turma_id_predef"
+        private const val ARG_DATA_PREDEF = "arg_data_predef"
+
+
+        fun newInstance(
+            planoId: Int? = null,
+            horarioAulaId: Int? = null,
+            disciplinaIdPredefinida: Int? = null,
+            turmaIdPredefinida: Int? = null,
+            dataPredefinida: String? = null // YYYY-MM-DD
+        ): FormularioPlanoDeAulaFragment {
+            val fragment = FormularioPlanoDeAulaFragment()
+            val args = Bundle()
+            planoId?.let { args.putInt(ARG_PLANO_ID, it) }
+            horarioAulaId?.let { args.putInt(ARG_HORARIO_AULA_ID, it) }
+            disciplinaIdPredefinida?.let { args.putInt(ARG_DISCIPLINA_ID_PREDEF, it) }
+            turmaIdPredefinida?.let { args.putInt(ARG_TURMA_ID_PREDEF, it) }
+            dataPredefinida?.let { args.putString(ARG_DATA_PREDEF, it) }
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            planoIdParaEdicao = if (it.containsKey(ARG_PLANO_ID)) it.getInt(ARG_PLANO_ID) else null
+            horarioAulaIdPredefinido = if (it.containsKey(ARG_HORARIO_AULA_ID)) it.getInt(ARG_HORARIO_AULA_ID) else null
+            disciplinaIdPredefinida = if (it.containsKey(ARG_DISCIPLINA_ID_PREDEF)) it.getInt(ARG_DISCIPLINA_ID_PREDEF) else null
+            turmaIdPredefinida = if (it.containsKey(ARG_TURMA_ID_PREDEF)) it.getInt(ARG_TURMA_ID_PREDEF) else null
+            dataPredefinida = if (it.containsKey(ARG_DATA_PREDEF)) it.getString(ARG_DATA_PREDEF) else null
+        }
+
+        val db = AppDatabase.getDatabase(requireContext())
+        planoDeAulaDao = db.planoDeAulaDao()
+        disciplinaDao = db.disciplinaDao()
+        turmaDao = db.turmaDao()
+        templateDao = db.templatePlanoAulaDao() // Inicializa o DAO
+
+        anexoLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK) {
+                result.data?.data?.let { uri ->
+                    anexoUri = uri
+                    anexoTipo = requireContext().contentResolver.getType(uri)
+                    // Obter nome do arquivo
+                    val cursor = requireContext().contentResolver.query(uri, null, null, null, null)
+                    cursor?.use {
+                        if (it.moveToFirst()) {
+                            val nameIndex = it.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                            if (nameIndex != -1) anexoNome = it.getString(nameIndex)
+                        }
+                    }
+                    binding.textViewNomeAnexoPlano.text = anexoNome ?: uri.lastPathSegment ?: "Arquivo selecionado"
+                }
+            }
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogFormularioPlanoDeAulaBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupSpinners()
+        setupDatePicker()
+        setupAnexoButton()
+
+        if (planoIdParaEdicao != null) {
+            binding.textViewFormularioPlanoTitulo.text = "Editar Plano de Aula"
+            carregarPlanoParaEdicao(planoIdParaEdicao!!)
+        } else {
+            binding.textViewFormularioPlanoTitulo.text = "Novo Plano de Aula"
+            preencherComDadosPredefinidos()
+        }
+
+        binding.buttonSalvarPlano.setOnClickListener { salvarPlano() }
+        binding.buttonCancelarPlano.setOnClickListener { dismiss() }
+    }
+
+    private fun preencherComDadosPredefinidos() {
+        if (dataPredefinida != null) {
+            try {
+                val date = storeDateFormat.parse(dataPredefinida!!)
+                dataAulaSelecionada = Calendar.getInstance().apply { time = date!! }
+                binding.editTextDataAulaPlano.setText(displayDateFormat.format(dataAulaSelecionada!!.time))
+            } catch (e: ParseException) { dataAulaSelecionada = null }
+        }
+        // A seleção dos spinners será feita quando eles forem populados, em setupSpinners
+    }
+
+
+    private fun setupSpinners() {
+        lifecycleScope.launch {
+            listaDisciplinas = withContext(Dispatchers.IO) { disciplinaDao.buscarTodas().first() }
+            val nomesDisciplinas = listaDisciplinas.map { it.nome }
+            val disciplinaAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesDisciplinas).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerDisciplinaPlano.adapter = disciplinaAdapter
+            disciplinaIdPredefinida?.let { predefId ->
+                val pos = listaDisciplinas.indexOfFirst { it.id == predefId }
+                if (pos != -1) binding.spinnerDisciplinaPlano.setSelection(pos)
+            }
+
+            // Popular Spinner de Turmas
+            listaTurmas = withContext(Dispatchers.IO) { turmaDao.buscarTodas().first() }
+            val nomesTurmasComOpcaoNenhuma = mutableListOf("Nenhuma (Geral)")
+            nomesTurmasComOpcaoNenhuma.addAll(listaTurmas.map { it.nome })
+            val turmaAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesTurmasComOpcaoNenhuma).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerTurmaPlano.adapter = turmaAdapter
+            turmaIdPredefinida?.let { predefId ->
+                 // +1 por causa da opção "Nenhuma"
+                val pos = listaTurmas.indexOfFirst { it.id == predefId }
+                if (pos != -1) binding.spinnerTurmaPlano.setSelection(pos + 1) else binding.spinnerTurmaPlano.setSelection(0)
+            } ?: binding.spinnerTurmaPlano.setSelection(0)
+
+            // Popular Spinner de Templates
+            templatesDisponiveis = withContext(Dispatchers.IO) { templateDao.buscarTodos().first() }
+            val nomesTemplatesComOpcaoNenhuma = mutableListOf("Nenhum (Personalizado)")
+            nomesTemplatesComOpcaoNenhuma.addAll(templatesDisponiveis.map { it.nomeTemplate })
+            val templateAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesTemplatesComOpcaoNenhuma).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerSelecionarTemplatePlano.adapter = templateAdapter
+            binding.spinnerSelecionarTemplatePlano.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+                override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                    if (position > 0) { // Posição 0 é "Nenhum"
+                        val templateSelecionado = templatesDisponiveis[position - 1]
+                        preencherCamposComTemplate(templateSelecionado)
+                    } else {
+                        // Opcional: Limpar campos se "Nenhum" for selecionado após um template
+                        // binding.editTextConteudoPlano.setText("") // Exemplo
+                    }
+                }
+                override fun onNothingSelected(parent: AdapterView<*>?) {}
+            }
+
+
+            // Se estiver editando, recarregar para garantir que os spinners são selecionados após serem populados
+            // Isso inclui o spinner de template.
+            if (planoIdParaEdicao != null && _binding != null) {
+                 carregarPlanoParaEdicao(planoIdParaEdicao!!, true) // O true agora significa apenas selecionar spinners
+            }
+        }
+    }
+
+    private fun preencherCamposComTemplate(template: TemplatePlanoAula) {
+        // Concatena os campos do template no campo de conteúdo principal.
+        // Uma UI mais elaborada teria campos separados no formulário do plano.
+        val sb = StringBuilder()
+        template.campoHabilidades?.let { if(it.isNotBlank()) sb.append("Habilidades:\n").append(it).append("\n\n") }
+        template.campoRecursos?.let { if(it.isNotBlank()) sb.append("Recursos:\n").append(it).append("\n\n") }
+        template.campoMetodologia?.let { if(it.isNotBlank()) sb.append("Metodologia/Estratégias:\n").append(it).append("\n\n") }
+        template.campoAvaliacao?.let { if(it.isNotBlank()) sb.append("Avaliação:\n").append(it).append("\n") }
+        // template.outrosCampos // Poderia ser parseado se fosse JSON e adicionado
+
+        binding.editTextConteudoPlano.setText(sb.toString().trim())
+        Toast.makeText(context, "Conteúdo preenchido com template: ${template.nomeTemplate}", Toast.LENGTH_SHORT).show()
+    }
+
+    private fun setupDatePicker() {
+        binding.editTextDataAulaPlano.setOnClickListener {
+            val calendarToShow = dataAulaSelecionada ?: Calendar.getInstance()
+            val year = calendarToShow.get(Calendar.YEAR)
+            val month = calendarToShow.get(Calendar.MONTH)
+            val day = calendarToShow.get(Calendar.DAY_OF_MONTH)
+
+            DatePickerDialog(requireContext(), { _, selectedYear, selectedMonth, selectedDayOfMonth ->
+                if(dataAulaSelecionada == null) dataAulaSelecionada = Calendar.getInstance()
+                dataAulaSelecionada!!.set(selectedYear, selectedMonth, selectedDayOfMonth)
+                binding.editTextDataAulaPlano.setText(displayDateFormat.format(dataAulaSelecionada!!.time))
+            }, year, month, day).show()
+        }
+    }
+
+    private fun setupAnexoButton() {
+        binding.buttonAnexarArquivoPlano.setOnClickListener {
+            val intent = Intent(Intent.ACTION_OPEN_DOCUMENT).apply {
+                addCategory(Intent.CATEGORY_OPENABLE)
+                type = "*/*" // Todos os tipos de arquivo
+            }
+            anexoLauncher.launch(intent)
+        }
+    }
+
+    private fun carregarPlanoParaEdicao(id: Int, apenasSelecionarSpinners: Boolean = false) {
+        lifecycleScope.launch {
+            val planoDisplay = withContext(Dispatchers.IO) { planoDeAulaDao.buscarDisplayPorId(id) }
+            planoDisplay?.let { pd ->
+                if (!apenasSelecionarSpinners && _binding != null) { // Evita repopular tudo se for só para spinners
+                    binding.editTextTituloPlano.setText(pd.planoDeAula.tituloPlano)
+                    if (pd.planoDeAula.dataAula != null) {
+                        try {
+                            val date = storeDateFormat.parse(pd.planoDeAula.dataAula!!)
+                            dataAulaSelecionada = Calendar.getInstance().apply { time = date!! }
+                            binding.editTextDataAulaPlano.setText(displayDateFormat.format(dataAulaSelecionada!!.time))
+                        } catch (e: ParseException) { dataAulaSelecionada = null; binding.editTextDataAulaPlano.text = null }
+                    } else {
+                        dataAulaSelecionada = null; binding.editTextDataAulaPlano.text = null
+                    }
+                    binding.editTextConteudoPlano.setText(pd.planoDeAula.textoPlano)
+                    anexoUri = pd.planoDeAula.caminhoAnexo?.let { Uri.parse(it) }
+                    anexoTipo = pd.planoDeAula.tipoAnexo
+                    // Nome do anexo não é armazenado diretamente, idealmente seria. Exibindo URI por enquanto.
+                    binding.textViewNomeAnexoPlano.text = anexoUri?.lastPathSegment ?: "Nenhum anexo"
+                    // Se o plano usou um template, pré-seleciona ele no spinner
+                    pd.planoDeAula.templateUsadoId?.let { templateId ->
+                        if (templatesDisponiveis.isNotEmpty()) {
+                            val templatePos = templatesDisponiveis.indexOfFirst { it.id == templateId }
+                            if (templatePos != -1) {
+                                binding.spinnerSelecionarTemplatePlano.setSelection(templatePos + 1) // +1 pela opção "Nenhum"
+                            }
+                        }
+                    }
+                }
+
+                // Selecionar spinners de Disciplina e Turma
+                if (listaDisciplinas.isNotEmpty()) {
+                    val discPos = listaDisciplinas.indexOfFirst { it.id == pd.planoDeAula.disciplinaId }
+                    if (discPos != -1) binding.spinnerDisciplinaPlano.setSelection(discPos)
+                }
+                if (listaTurmas.isNotEmpty()) {
+                    val turmaPos = listaTurmas.indexOfFirst { it.id == pd.planoDeAula.turmaId }
+                    if (turmaPos != -1) binding.spinnerTurmaPlano.setSelection(turmaPos + 1) else binding.spinnerTurmaPlano.setSelection(0)
+                } else {
+                     binding.spinnerTurmaPlano.setSelection(0)
+                }
+            }
+        }
+    }
+
+    private fun salvarPlano() {
+        val titulo = binding.editTextTituloPlano.text.toString().trim()
+        val conteudo = binding.editTextConteudoPlano.text.toString().trim()
+
+        if (binding.spinnerDisciplinaPlano.selectedItemPosition < 0 || listaDisciplinas.isEmpty()) {
+            Toast.makeText(context, "Selecione uma disciplina.", Toast.LENGTH_SHORT).show()
+            return
+        }
+        val disciplinaSelecionada = listaDisciplinas[binding.spinnerDisciplinaPlano.selectedItemPosition]
+
+        val turmaSelecionadaId: Int? = if (binding.spinnerTurmaPlano.selectedItemPosition > 0 && listaTurmas.isNotEmpty()) {
+            listaTurmas[binding.spinnerTurmaPlano.selectedItemPosition - 1].id // -1 por causa da opção "Nenhuma"
+        } else {
+            null
+        }
+
+        val dataAulaFormatada: String? = dataAulaSelecionada?.let { storeDateFormat.format(it.time) }
+
+        val templateSelecionadoId: Int? = if (binding.spinnerSelecionarTemplatePlano.selectedItemPosition > 0 && templatesDisponiveis.isNotEmpty()) {
+            templatesDisponiveis[binding.spinnerSelecionarTemplatePlano.selectedItemPosition - 1].id
+        } else {
+            null
+        }
+
+        if (disciplinaSelecionada == null) {
+            Toast.makeText(context, "Disciplina é obrigatória.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        val planoParaSalvar = PlanoDeAula(
+            id = planoIdParaEdicao ?: 0,
+            horarioAulaId = horarioAulaIdPredefinido,
+            dataAula = dataAulaFormatada,
+            disciplinaId = disciplinaSelecionada.id,
+            turmaId = turmaSelecionadaId,
+            tituloPlano = titulo.ifEmpty { null },
+            textoPlano = conteudo.ifEmpty { null },
+            caminhoAnexo = anexoUri?.toString(),
+            tipoAnexo = anexoTipo,
+            templateUsadoId = templateSelecionadoId
+        )
+        listener?.onPlanoSalvo(planoParaSalvar)
+        dismiss()
+    }
+
+    fun setListener(listener: FormularioPlanoListener) {
+        this.listener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioTarefaFragment.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioTarefaFragment.kt
@@ -1,0 +1,362 @@
+package com.agendafocopei.ui.dialog
+
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.graphics.Color
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.R
+import com.agendafocopei.data.*
+import com.agendafocopei.databinding.DialogFormularioTarefaBinding
+import com.agendafocopei.ui.adapter.SubtarefaAdapter
+import com.google.android.material.textfield.TextInputEditText
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.*
+
+class FormularioTarefaFragment : DialogFragment(), ColorPickerDialogFragment.ColorPickerListener {
+
+    private var _binding: DialogFormularioTarefaBinding? = null
+    private val binding get() = _binding!!
+
+    interface FormularioTarefaListener {
+        // Passar a tarefa e a lista de subtarefas para a Activity salvar
+        fun onTarefaSalva(tarefa: Tarefa, subtarefas: List<Subtarefa>)
+    }
+
+    private var listener: FormularioTarefaListener? = null
+    private var tarefaIdParaEdicao: Int? = null
+    private var tarefaParaEdicao: Tarefa? = null
+
+    private lateinit var tarefaDao: TarefaDao
+    private lateinit var disciplinaDao: DisciplinaDao
+    private lateinit var turmaDao: TurmaDao
+    private lateinit var subtarefaDao: SubtarefaDao
+
+    private var listaDisciplinas: List<Disciplina> = emptyList()
+    private var listaTurmas: List<Turma> = emptyList()
+    private val listaSubtarefas = mutableListOf<Subtarefa>()
+    private lateinit var subtarefaAdapter: SubtarefaAdapter
+
+    private var prazoCalendar: Calendar? = null
+    private val displayDateFormat = SimpleDateFormat("dd/MM/yyyy", Locale("pt", "BR"))
+    private val storeDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+    private val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
+
+    private val deltasLembreteMillis = listOf(
+        -1L, 0L, 5 * 60 * 1000L, 10 * 60 * 1000L, 30 * 60 * 1000L,
+        60 * 60 * 1000L, 2 * 60 * 60 * 1000L, 24 * 60 * 60 * 1000L
+    )
+
+    companion object {
+        const val TAG = "FormularioTarefaDialog"
+        private const val ARG_TAREFA_ID = "arg_tarefa_id"
+
+        fun newInstance(tarefaId: Int? = null): FormularioTarefaFragment {
+            val fragment = FormularioTarefaFragment()
+            val args = Bundle()
+            tarefaId?.let { args.putInt(ARG_TAREFA_ID, it) }
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            if (it.containsKey(ARG_TAREFA_ID)) {
+                tarefaIdParaEdicao = it.getInt(ARG_TAREFA_ID)
+            }
+        }
+        val db = AppDatabase.getDatabase(requireContext())
+        tarefaDao = db.tarefaDao()
+        disciplinaDao = db.disciplinaDao()
+        turmaDao = db.turmaDao()
+        subtarefaDao = db.subtarefaDao()
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogFormularioTarefaBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupSpinners()
+        setupDateTimePickers()
+        setupSubtarefasRecyclerView()
+
+        if (tarefaIdParaEdicao != null) {
+            binding.textViewFormularioTarefaTitulo.text = "Editar Tarefa"
+            carregarTarefaParaEdicao(tarefaIdParaEdicao!!)
+        } else {
+            binding.textViewFormularioTarefaTitulo.text = "Nova Tarefa"
+            binding.spinnerPrioridadeTarefa.setSelection(1)
+            atualizarEstadoSpinnerLembrete()
+            subtarefaAdapter.submitList(emptyList())
+        }
+
+        binding.buttonSalvarTarefa.setOnClickListener { salvarTarefaESubtarefas() }
+        binding.buttonCancelarTarefa.setOnClickListener { dismiss() }
+        binding.buttonLimparPrazoTarefa.setOnClickListener {
+            prazoCalendar = null
+            binding.editTextPrazoDataTarefa.setText("")
+            binding.editTextPrazoHoraTarefa.setText("")
+            atualizarEstadoSpinnerLembrete()
+        }
+        binding.buttonAdicionarSubtarefa.setOnClickListener { adicionarNovaSubtarefa() }
+    }
+
+    private fun setupSubtarefasRecyclerView() {
+        subtarefaAdapter = SubtarefaAdapter(
+            onItemCheckedChange = { subtarefa, isChecked ->
+                val index = listaSubtarefas.indexOfFirst { it.id == subtarefa.id && (it.id != 0 || it.descricaoSubtarefa == subtarefa.descricaoSubtarefa) }
+                if (index != -1) {
+                    listaSubtarefas[index] = listaSubtarefas[index].copy(concluida = isChecked)
+                }
+            },
+            onItemDescriptionChange = { subtarefa, newDescription ->
+                val index = listaSubtarefas.indexOfFirst { it.id == subtarefa.id && (it.id != 0 || it.descricaoSubtarefa == subtarefa.descricaoSubtarefa) }
+                if (index != -1) {
+                     // Apenas atualiza se o texto realmente mudou para evitar loops com TextWatcher
+                    if (listaSubtarefas[index].descricaoSubtarefa != newDescription) {
+                        listaSubtarefas[index] = listaSubtarefas[index].copy(descricaoSubtarefa = newDescription)
+                    }
+                }
+            },
+            onDeleteClickListener = { subtarefa ->
+                val itemToRemove = listaSubtarefas.find { it.id == subtarefa.id && (it.id != 0 || it.descricaoSubtarefa == subtarefa.descricaoSubtarefa) }
+                itemToRemove?.let {
+                    listaSubtarefas.remove(it)
+                    subtarefaAdapter.submitList(listaSubtarefas.toList())
+                }
+            }
+        )
+        binding.recyclerViewSubtarefas.apply {
+            layoutManager = LinearLayoutManager(requireContext())
+            adapter = subtarefaAdapter
+        }
+    }
+
+    private fun adicionarNovaSubtarefa() {
+        val descricao = binding.editTextNovaSubtarefa.text.toString().trim()
+        if (descricao.isNotEmpty()) {
+            val novaSubtarefa = Subtarefa(
+                // id é 0 para novo, tarefaId será setado ao salvar a tarefa principal
+                tarefaId = tarefaIdParaEdicao ?: 0, // Temporário se for nova tarefa
+                descricaoSubtarefa = descricao,
+                concluida = false,
+                ordem = listaSubtarefas.size
+            )
+            listaSubtarefas.add(novaSubtarefa)
+            subtarefaAdapter.submitList(listaSubtarefas.toList())
+            binding.editTextNovaSubtarefa.text?.clear()
+        } else {
+            Toast.makeText(context, "Descrição da subtarefa não pode ser vazia.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    private fun setupSpinners() {
+        ArrayAdapter.createFromResource(
+            requireContext(), R.array.prioridades_array, android.R.layout.simple_spinner_item
+        ).also { adapter ->
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            binding.spinnerPrioridadeTarefa.adapter = adapter
+        }
+        ArrayAdapter.createFromResource(
+            requireContext(), R.array.opcoes_lembrete_array, android.R.layout.simple_spinner_item
+        ).also { adapter ->
+            adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            binding.spinnerLembreteTarefa.adapter = adapter
+        }
+        lifecycleScope.launch {
+            listaDisciplinas = withContext(Dispatchers.IO) { disciplinaDao.buscarTodas().first() }
+            val nomesDisciplinasComOpcao = listOf("Nenhuma") + listaDisciplinas.map { it.nome }
+            val disciplinaAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesDisciplinasComOpcao).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerDisciplinaTarefa.adapter = disciplinaAdapter
+
+            listaTurmas = withContext(Dispatchers.IO) { turmaDao.buscarTodas().first() }
+            val nomesTurmasComOpcao = listOf("Nenhuma") + listaTurmas.map { it.nome }
+            val turmaAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesTurmasComOpcao).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerTurmaTarefa.adapter = turmaAdapter
+
+            if (tarefaIdParaEdicao != null && tarefaParaEdicao != null) {
+                selecionarValoresSpinnerEdicao(tarefaParaEdicao!!)
+            }
+        }
+    }
+
+    private fun setupDateTimePickers() {
+        binding.editTextPrazoDataTarefa.setOnClickListener {
+            val cal = prazoCalendar ?: Calendar.getInstance()
+            DatePickerDialog(requireContext(), { _, year, month, dayOfMonth ->
+                if (prazoCalendar == null) prazoCalendar = Calendar.getInstance()
+                prazoCalendar!!.clear(Calendar.HOUR_OF_DAY); prazoCalendar!!.clear(Calendar.MINUTE); prazoCalendar!!.clear(Calendar.SECOND); prazoCalendar!!.clear(Calendar.MILLISECOND)
+                prazoCalendar!!.set(year, month, dayOfMonth)
+                binding.editTextPrazoDataTarefa.setText(displayDateFormat.format(prazoCalendar!!.time))
+                if(binding.editTextPrazoHoraTarefa.text.isNullOrEmpty()){
+                    prazoCalendar!!.set(Calendar.HOUR_OF_DAY, 8); prazoCalendar!!.set(Calendar.MINUTE, 0)
+                    binding.editTextPrazoHoraTarefa.setText(timeFormat.format(prazoCalendar!!.time))
+                }
+                atualizarEstadoSpinnerLembrete()
+            }, cal.get(Calendar.YEAR), cal.get(Calendar.MONTH), cal.get(Calendar.DAY_OF_MONTH)).show()
+        }
+        binding.editTextPrazoHoraTarefa.setOnClickListener {
+            if (prazoCalendar == null || binding.editTextPrazoDataTarefa.text.isNullOrEmpty()) {
+                 Toast.makeText(requireContext(), "Selecione uma data de prazo primeiro.", Toast.LENGTH_SHORT).show()
+                 return@setOnClickListener
+            }
+            val cal = prazoCalendar!!
+            TimePickerDialog(requireContext(), { _, hourOfDay, minute ->
+                prazoCalendar!!.set(Calendar.HOUR_OF_DAY, hourOfDay); prazoCalendar!!.set(Calendar.MINUTE, minute)
+                binding.editTextPrazoHoraTarefa.setText(timeFormat.format(prazoCalendar!!.time))
+                atualizarEstadoSpinnerLembrete()
+            }, cal.get(Calendar.HOUR_OF_DAY), cal.get(Calendar.MINUTE), true).show()
+        }
+    }
+
+    private fun atualizarEstadoSpinnerLembrete() {
+        val prazoTotalmenteDefinido = prazoCalendar != null &&
+                                    !binding.editTextPrazoDataTarefa.text.isNullOrEmpty() &&
+                                    !binding.editTextPrazoHoraTarefa.text.isNullOrEmpty()
+        binding.spinnerLembreteTarefa.isEnabled = prazoTotalmenteDefinido
+        binding.textViewLabelLembrete.isEnabled = prazoTotalmenteDefinido
+        if (!prazoTotalmenteDefinido) {
+            binding.spinnerLembreteTarefa.setSelection(0)
+        }
+    }
+
+    private fun carregarTarefaParaEdicao(id: Int) {
+        lifecycleScope.launch {
+            tarefaParaEdicao = withContext(Dispatchers.IO) { tarefaDao.buscarPorId(id) }
+            tarefaParaEdicao?.let { tarefa ->
+                binding.editTextDescricaoTarefa.setText(tarefa.descricao)
+                prazoCalendar = null
+                binding.editTextPrazoDataTarefa.setText("")
+                binding.editTextPrazoHoraTarefa.setText("")
+                if (tarefa.prazoData != null) {
+                    try {
+                        val date = storeDateFormat.parse(tarefa.prazoData!!)
+                        prazoCalendar = Calendar.getInstance().apply { time = date!! }
+                        binding.editTextPrazoDataTarefa.setText(displayDateFormat.format(prazoCalendar!!.time))
+                        if (tarefa.prazoHora != null) {
+                            val timeCal = Calendar.getInstance()
+                            timeCal.time = timeFormat.parse(tarefa.prazoHora!!) ?: Date()
+                            prazoCalendar!!.set(Calendar.HOUR_OF_DAY, timeCal.get(Calendar.HOUR_OF_DAY))
+                            prazoCalendar!!.set(Calendar.MINUTE, timeCal.get(Calendar.MINUTE))
+                            binding.editTextPrazoHoraTarefa.setText(tarefa.prazoHora)
+                        }
+                    } catch (e: ParseException) { prazoCalendar = null }
+                }
+                binding.spinnerPrioridadeTarefa.setSelection(tarefa.prioridade)
+
+                if(listaDisciplinas.isNotEmpty() || listaTurmas.isNotEmpty()){
+                    selecionarValoresSpinnerEdicao(tarefa)
+                }
+
+                if (tarefa.lembreteConfigurado && tarefa.lembreteDateTime != null && prazoCalendar != null) {
+                    val diffMillis = prazoCalendar!!.timeInMillis - tarefa.lembreteDateTime!!
+                    val indexNoSpinner = deltasLembreteMillis.indexOfFirst { it == diffMillis }
+                    if (indexNoSpinner != -1 && indexNoSpinner < binding.spinnerLembreteTarefa.adapter.count) {
+                        binding.spinnerLembreteTarefa.setSelection(indexNoSpinner)
+                    } else { binding.spinnerLembreteTarefa.setSelection(0) }
+                } else { binding.spinnerLembreteTarefa.setSelection(0) }
+                atualizarEstadoSpinnerLembrete()
+
+                // Carregar subtarefas
+                subtarefaDao.buscarPorTarefaId(tarefa.id).collect { subtarefasDoBanco ->
+                    listaSubtarefas.clear()
+                    listaSubtarefas.addAll(subtarefasDoBanco)
+                    subtarefaAdapter.submitList(listaSubtarefas.toList())
+                }
+            }
+        }
+    }
+
+    private fun selecionarValoresSpinnerEdicao(tarefa: Tarefa){
+        val discPos = tarefa.disciplinaId?.let { discId -> listaDisciplinas.indexOfFirst { it.id == discId } } ?: -1
+        binding.spinnerDisciplinaTarefa.setSelection(if (discPos != -1) discPos + 1 else 0)
+        val turmaPos = tarefa.turmaId?.let { turId -> listaTurmas.indexOfFirst { it.id == turId } } ?: -1
+        binding.spinnerTurmaTarefa.setSelection(if (turmaPos != -1) turmaPos + 1 else 0)
+    }
+
+    private fun salvarTarefaESubtarefas() {
+        val descricao = binding.editTextDescricaoTarefa.text.toString().trim()
+        if (descricao.isEmpty()) {
+            binding.editTextDescricaoTarefa.error = "Descrição é obrigatória"; return
+        } else { binding.editTextDescricaoTarefa.error = null }
+
+        val prazoDataStr: String? = if (prazoCalendar != null && !binding.editTextPrazoDataTarefa.text.isNullOrEmpty()) storeDateFormat.format(prazoCalendar!!.time) else null
+        val prazoHoraStr: String? = if (prazoCalendar != null && prazoDataStr != null && !binding.editTextPrazoHoraTarefa.text.isNullOrEmpty()) timeFormat.format(prazoCalendar!!.time) else null
+
+        if (prazoDataStr == null && prazoHoraStr != null) {
+            Toast.makeText(requireContext(), "Selecione uma data para o prazo se uma hora foi definida.", Toast.LENGTH_SHORT).show(); return
+        }
+        if (prazoDataStr != null && prazoHoraStr == null) {
+             Toast.makeText(requireContext(), "Defina uma hora para o prazo ou limpe a data.", Toast.LENGTH_SHORT).show(); return
+        }
+
+        val prioridade = binding.spinnerPrioridadeTarefa.selectedItemPosition
+        val disciplinaIdSelecionada: Int? = if (binding.spinnerDisciplinaTarefa.selectedItemPosition > 0 && listaDisciplinas.isNotEmpty()) listaDisciplinas[binding.spinnerDisciplinaTarefa.selectedItemPosition - 1].id else null
+        val turmaIdSelecionada: Int? = if (binding.spinnerTurmaTarefa.selectedItemPosition > 0 && listaTurmas.isNotEmpty()) listaTurmas[binding.spinnerTurmaTarefa.selectedItemPosition - 1].id else null
+
+        var lembreteConfig = false
+        var lembreteTs: Long? = null
+        val lembreteSpinnerPos = binding.spinnerLembreteTarefa.selectedItemPosition
+        if (prazoCalendar != null && prazoDataStr != null && prazoHoraStr != null && lembreteSpinnerPos > 0 && lembreteSpinnerPos < deltasLembreteMillis.size) {
+            lembreteTs = prazoCalendar!!.timeInMillis - deltasLembreteMillis[lembreteSpinnerPos]
+            lembreteConfig = true
+        }
+
+        val tarefaParaSalvar = Tarefa(
+            id = tarefaIdParaEdicao ?: 0,
+            descricao = descricao,
+            prazoData = prazoDataStr,
+            prazoHora = prazoHoraStr,
+            prioridade = prioridade,
+            disciplinaId = disciplinaIdSelecionada,
+            turmaId = turmaIdSelecionada,
+            concluida = tarefaParaEdicao?.concluida ?: false,
+            dataCriacao = tarefaParaEdicao?.dataCriacao ?: System.currentTimeMillis(),
+            dataConclusao = tarefaParaEdicao?.dataConclusao,
+            lembreteConfigurado = lembreteConfig,
+            lembreteDateTime = lembreteTs
+        )
+
+        // A Activity agora é responsável por salvar a tarefa principal e depois as subtarefas
+        listener?.onTarefaSalva(tarefaParaSalvar, listaSubtarefas.toList()) // Passa a lista atual de subtarefas
+        dismiss()
+    }
+
+    override fun onColorSelected(color: Int, tag: String?) { /* Não aplicável */ }
+
+    fun setListener(listener: FormularioTarefaListener) {
+        this.listener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioTemplatePlanoAulaFragment.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/dialog/FormularioTemplatePlanoAulaFragment.kt
@@ -1,0 +1,123 @@
+package com.agendafocopei.ui.dialog
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.TemplatePlanoAula
+import com.agendafocopei.data.TemplatePlanoAulaDao
+import com.agendafocopei.databinding.DialogFormularioTemplatePlanoAulaBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class FormularioTemplatePlanoAulaFragment : DialogFragment() {
+
+    private var _binding: DialogFormularioTemplatePlanoAulaBinding? = null
+    private val binding get() = _binding!!
+
+    interface FormularioTemplateListener {
+        fun onTemplateSalvo(template: TemplatePlanoAula)
+    }
+
+    private var listener: FormularioTemplateListener? = null
+    private var templateIdParaEdicao: Int? = null
+
+    private lateinit var templateDao: TemplatePlanoAulaDao
+
+    companion object {
+        const val TAG = "FormularioTemplateDialog"
+        private const val ARG_TEMPLATE_ID = "arg_template_id"
+
+        fun newInstance(templateId: Int? = null): FormularioTemplatePlanoAulaFragment {
+            val fragment = FormularioTemplatePlanoAulaFragment()
+            val args = Bundle()
+            templateId?.let { args.putInt(ARG_TEMPLATE_ID, it) }
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            if (it.containsKey(ARG_TEMPLATE_ID)) {
+                templateIdParaEdicao = it.getInt(ARG_TEMPLATE_ID)
+            }
+        }
+        templateDao = AppDatabase.getDatabase(requireContext()).templatePlanoAulaDao()
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogFormularioTemplatePlanoAulaBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        if (templateIdParaEdicao != null) {
+            binding.textViewFormularioTemplateTitulo.text = "Editar Template"
+            carregarTemplateParaEdicao(templateIdParaEdicao!!)
+        } else {
+            binding.textViewFormularioTemplateTitulo.text = "Novo Template de Plano de Aula"
+        }
+
+        binding.buttonSalvarTemplate.setOnClickListener { salvarTemplate() }
+        binding.buttonCancelarTemplate.setOnClickListener { dismiss() }
+    }
+
+    private fun carregarTemplateParaEdicao(id: Int) {
+        lifecycleScope.launch {
+            val template = withContext(Dispatchers.IO) { templateDao.buscarPorId(id) }
+            template?.let {
+                binding.editTextNomeTemplateForm.setText(it.nomeTemplate)
+                binding.editTextCampoHabilidades.setText(it.campoHabilidades)
+                binding.editTextCampoRecursos.setText(it.campoRecursos)
+                binding.editTextCampoMetodologia.setText(it.campoMetodologia)
+                binding.editTextCampoAvaliacao.setText(it.campoAvaliacao)
+                // Lidar com outros_campos se houver UI para ele
+            }
+        }
+    }
+
+    private fun salvarTemplate() {
+        val nomeTemplate = binding.editTextNomeTemplateForm.text.toString().trim()
+        if (nomeTemplate.isEmpty()) {
+            binding.editTextNomeTemplateForm.error = "Nome do template é obrigatório."
+            return
+        } else {
+            binding.editTextNomeTemplateForm.error = null
+        }
+
+        val template = TemplatePlanoAula(
+            id = templateIdParaEdicao ?: 0,
+            nomeTemplate = nomeTemplate,
+            campoHabilidades = binding.editTextCampoHabilidades.text.toString().trim().ifEmpty { null },
+            campoRecursos = binding.editTextCampoRecursos.text.toString().trim().ifEmpty { null },
+            campoMetodologia = binding.editTextCampoMetodologia.text.toString().trim().ifEmpty { null },
+            campoAvaliacao = binding.editTextCampoAvaliacao.text.toString().trim().ifEmpty { null },
+            outrosCampos = null // A ser implementado se houver UI
+        )
+        listener?.onTemplateSalvo(template)
+        dismiss()
+    }
+
+    fun setListener(listener: FormularioTemplateListener) {
+        this.listener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/GuiaDeAprendizagemDisplay.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/GuiaDeAprendizagemDisplay.kt
@@ -1,0 +1,17 @@
+package com.agendafocopei.ui.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import com.agendafocopei.data.GuiaDeAprendizagem
+
+data class GuiaDeAprendizagemDisplay(
+    @Embedded val guiaDeAprendizagem: GuiaDeAprendizagem,
+
+    @ColumnInfo(name = "nome_disciplina")
+    val nomeDisciplina: String?,
+
+    @ColumnInfo(name = "cor_disciplina")
+    val corDisciplina: Int?
+    // Adicionar contagem de itens do checklist se necessário diretamente aqui,
+    // ou calcular depois.
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/HorarioAulaDisplay.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/HorarioAulaDisplay.kt
@@ -10,8 +10,10 @@ data class HorarioAulaDisplay(
     val horaFim: String,
     val nomeDisciplina: String,
     val corDisciplina: Int?,
+    val disciplinaId: Int, // NOVO
     val nomeTurma: String,
     val corTurma: Int?,
+    val turmaId: Int, // NOVO
     val salaAula: String?
 ) {
     fun getDiaDaSemanaFormatado(): String {

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/PlanoDeAulaDisplay.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/PlanoDeAulaDisplay.kt
@@ -1,0 +1,21 @@
+package com.agendafocopei.ui.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import com.agendafocopei.data.PlanoDeAula
+
+data class PlanoDeAulaDisplay(
+    @Embedded val planoDeAula: PlanoDeAula,
+
+    @ColumnInfo(name = "nome_disciplina")
+    val nomeDisciplina: String?,
+
+    @ColumnInfo(name = "cor_disciplina") // Adicionando cor para exibição
+    val corDisciplina: Int?,
+
+    @ColumnInfo(name = "nome_turma")
+    val nomeTurma: String?,
+
+    @ColumnInfo(name = "cor_turma") // Adicionando cor para exibição
+    val corTurma: Int?
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/TarefaDisplay.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/model/TarefaDisplay.kt
@@ -1,0 +1,21 @@
+package com.agendafocopei.ui.model
+
+import androidx.room.ColumnInfo
+import androidx.room.Embedded
+import com.agendafocopei.data.Tarefa
+
+data class TarefaDisplay(
+    @Embedded val tarefa: Tarefa,
+
+    @ColumnInfo(name = "nome_disciplina")
+    val nomeDisciplina: String?,
+
+    @ColumnInfo(name = "cor_disciplina")
+    val corDisciplina: Int?,
+
+    @ColumnInfo(name = "nome_turma")
+    val nomeTurma: String?,
+
+    @ColumnInfo(name = "cor_turma")
+    val corTurma: Int?
+)

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/pomodoro/ConfigPomodoroDialogFragment.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/pomodoro/ConfigPomodoroDialogFragment.kt
@@ -1,0 +1,123 @@
+package com.agendafocopei.ui.pomodoro
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import com.agendafocopei.databinding.DialogConfigPomodoroBinding
+import java.util.concurrent.TimeUnit
+
+class ConfigPomodoroDialogFragment : DialogFragment() {
+
+    private var _binding: DialogConfigPomodoroBinding? = null
+    private val binding get() = _binding!!
+
+    interface ConfigPomodoroListener {
+        fun onConfigSalva(focoMin: Int, curtaMin: Int, longaMin: Int, ciclos: Int, hiperfoco: Boolean, som: Boolean)
+    }
+
+    private var listener: ConfigPomodoroListener? = null
+    private lateinit var prefs: SharedPreferences
+
+    companion object {
+        const val TAG = "ConfigPomodoroDialog"
+        // SharedPreferences Keys (serão movidas/usadas pelo ViewModel também)
+        const val PREFS_NAME = "pomodoro_prefs"
+        const val KEY_FOCO_MIN = "foco_min"
+        const val KEY_PAUSA_CURTA_MIN = "pausa_curta_min"
+        const val KEY_PAUSA_LONGA_MIN = "pausa_longa_min"
+        const val KEY_CICLOS_ATE_PAUSA_LONGA = "ciclos_pausa_longa"
+        const val KEY_MODO_HIPERFOCO = "modo_hiperfoco" // Pausas mais curtas ainda
+        const val KEY_ALARME_SONORO = "alarme_sonoro"
+
+
+        fun newInstance(): ConfigPomodoroDialogFragment {
+            return ConfigPomodoroDialogFragment()
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        // Tenta setar o listener a partir da Activity ou Fragment pai
+        listener = parentFragment as? ConfigPomodoroListener ?: activity as? ConfigPomodoroListener
+    }
+
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogConfigPomodoroBinding.inflate(inflater, container, false)
+        prefs = requireActivity().getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.setTitle("Configurações do Pomodoro")
+
+        carregarConfiguracoes()
+
+        binding.buttonSalvarConfigPomodoro.setOnClickListener {
+            salvarEFechar()
+        }
+        binding.buttonCancelarConfigPomodoro.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    private fun carregarConfiguracoes() {
+        binding.editTextTempoFocoConfig.setText(prefs.getInt(KEY_FOCO_MIN, 25).toString())
+        binding.editTextPausaCurtaConfig.setText(prefs.getInt(KEY_PAUSA_CURTA_MIN, 5).toString())
+        binding.editTextPausaLongaConfig.setText(prefs.getInt(KEY_PAUSA_LONGA_MIN, 15).toString())
+        binding.editTextCiclosPausaLongaConfig.setText(prefs.getInt(KEY_CICLOS_ATE_PAUSA_LONGA, 4).toString())
+        binding.switchModoHiperfocoConfig.isChecked = prefs.getBoolean(KEY_MODO_HIPERFOCO, false)
+        binding.switchAlarmeSonoroConfig.isChecked = prefs.getBoolean(KEY_ALARME_SONORO, true)
+    }
+
+    private fun salvarEFechar() {
+        val focoMin = binding.editTextTempoFocoConfig.text.toString().toIntOrNull() ?: 25
+        val pausaCurtaMin = binding.editTextPausaCurtaConfig.text.toString().toIntOrNull() ?: 5
+        val pausaLongaMin = binding.editTextPausaLongaConfig.text.toString().toIntOrNull() ?: 15
+        val ciclos = binding.editTextCiclosPausaLongaConfig.text.toString().toIntOrNull() ?: 4
+        val hiperfoco = binding.switchModoHiperfocoConfig.isChecked
+        val som = binding.switchAlarmeSonoroConfig.isChecked
+
+        // Validação simples
+        if (focoMin <= 0 || pausaCurtaMin <= 0 || pausaLongaMin <= 0 || ciclos <= 0) {
+            Toast.makeText(context, "Valores devem ser maiores que zero.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        // Salva nas SharedPreferences (ViewModel também fará isso ao ser inicializado ou modificado)
+        prefs.edit().apply {
+            putInt(KEY_FOCO_MIN, focoMin)
+            putInt(KEY_PAUSA_CURTA_MIN, pausaCurtaMin)
+            putInt(KEY_PAUSA_LONGA_MIN, pausaLongaMin)
+            putInt(KEY_CICLOS_ATE_PAUSA_LONGA, ciclos)
+            putBoolean(KEY_MODO_HIPERFOCO, hiperfoco)
+            putBoolean(KEY_ALARME_SONORO, som)
+            apply()
+        }
+
+        listener?.onConfigSalva(focoMin, pausaCurtaMin, pausaLongaMin, ciclos, hiperfoco, som)
+        dismiss()
+    }
+
+    // Método para Activity setar o listener (se não usar a abordagem do onAttach)
+    // fun setListener(listener: ConfigPomodoroListener) {
+    //     this.listener = listener
+    // }
+
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/pomodoro/PomodoroViewModel.kt
+++ b/AgendaFocoPEI/app/src/main/java/com/agendafocopei/ui/pomodoro/PomodoroViewModel.kt
@@ -1,0 +1,336 @@
+package com.agendafocopei.ui.pomodoro
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.media.MediaPlayer // Para o som
+import android.os.CountDownTimer
+import android.util.Log
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.agendafocopei.R // Para R.raw e R.drawable
+import com.agendafocopei.ui.activity.PomodoroActivity // Para o PendingIntent
+import java.util.concurrent.TimeUnit
+
+enum class PomodoroState { PRONTO, FOCO, PAUSA_CURTA, PAUSA_LONGA, PAUSADO }
+
+class PomodoroViewModel : ViewModel() {
+
+    companion object {
+        const val PREFS_NAME = "pomodoro_prefs"
+        const val KEY_FOCO_MIN = "foco_min"
+        const val KEY_PAUSA_CURTA_MIN = "pausa_curta_min"
+        const val KEY_PAUSA_LONGA_MIN = "pausa_longa_min"
+        const val KEY_CICLOS_ATE_PAUSA_LONGA = "ciclos_pausa_longa"
+        const val KEY_MODO_HIPERFOCO = "modo_hiperfoco"
+        const val KEY_ALARME_SONORO = "alarme_sonoro"
+        private const val NOTIFICATION_ID = 123098 // ID único para a notificação Pomodoro
+        private const val POMODORO_CHANNEL_ID = "POMODORO_CHANNEL_ID" // Deve ser o mesmo da Activity
+    }
+
+    private lateinit var prefs: SharedPreferences
+    private var appContext: Context? = null
+
+    val duracaoFocoMillis = MutableLiveData(TimeUnit.MINUTES.toMillis(25))
+    val duracaoPausaCurtaMillis = MutableLiveData(TimeUnit.MINUTES.toMillis(5))
+    val duracaoPausaLongaMillis = MutableLiveData(TimeUnit.MINUTES.toMillis(15))
+    val ciclosAtePausaLonga = MutableLiveData(4)
+    val ativarModoHiperfoco = MutableLiveData(false)
+    val ativarAlarmeSonoro = MutableLiveData(true)
+
+    private val _tempoRestanteMillis = MutableLiveData<Long>()
+    val tempoRestanteMillis: LiveData<Long> get() = _tempoRestanteMillis
+
+    private val _estadoAtual = MutableLiveData<PomodoroState>(PomodoroState.PRONTO)
+    val estadoAtual: LiveData<PomodoroState> get() = _estadoAtual
+
+    private val _cicloFocoAtual = MutableLiveData<Int>(0)
+    val cicloFocoAtual: LiveData<Int> get() = _cicloFocoAtual
+
+    private val _tempoTotalCicloAtualMillis = MutableLiveData<Long>()
+    val tempoTotalCicloAtualMillis: LiveData<Long> get() = _tempoTotalCicloAtualMillis
+
+    private var countDownTimer: CountDownTimer? = null
+    private var ciclosDeFocoCompletosNaSequencia: Int = 0
+    private var millisRestantesAoPausar: Long = 0
+    private var estadoAntesDePausar: PomodoroState = PomodoroState.PRONTO
+    private var filtroInterrupcaoAnterior: Int? = null
+    private var dndAtivadoPeloViewModel = false
+    private var mediaPlayer: MediaPlayer? = null
+
+
+    fun inicializarComPrefs(context: Context, sharedPreferences: SharedPreferences) {
+        this.appContext = context.applicationContext
+        prefs = sharedPreferences
+        carregarConfiguracoes()
+        resetarParaEstadoInicial(this.appContext!!)
+    }
+
+    private fun carregarConfiguracoes() {
+        duracaoFocoMillis.value = TimeUnit.MINUTES.toMillis(prefs.getInt(KEY_FOCO_MIN, 25).toLong())
+        duracaoPausaCurtaMillis.value = TimeUnit.MINUTES.toMillis(prefs.getInt(KEY_PAUSA_CURTA_MIN, 5).toLong())
+        duracaoPausaLongaMillis.value = TimeUnit.MINUTES.toMillis(prefs.getInt(KEY_PAUSA_LONGA_MIN, 15).toLong())
+        ciclosAtePausaLonga.value = prefs.getInt(KEY_CICLOS_ATE_PAUSA_LONGA, 4)
+        ativarModoHiperfoco.value = prefs.getBoolean(KEY_MODO_HIPERFOCO, false)
+        ativarAlarmeSonoro.value = prefs.getBoolean(KEY_ALARME_SONORO, true)
+    }
+
+    private fun salvarConfiguracoes() {
+        if (!this::prefs.isInitialized) return
+        prefs.edit().apply {
+            putInt(KEY_FOCO_MIN, TimeUnit.MILLISECONDS.toMinutes(duracaoFocoMillis.value ?: TimeUnit.MINUTES.toMillis(25)).toInt())
+            putInt(KEY_PAUSA_CURTA_MIN, TimeUnit.MILLISECONDS.toMinutes(duracaoPausaCurtaMillis.value ?: TimeUnit.MINUTES.toMillis(5)).toInt())
+            putInt(KEY_PAUSA_LONGA_MIN, TimeUnit.MILLISECONDS.toMinutes(duracaoPausaLongaMillis.value ?: TimeUnit.MINUTES.toMillis(15)).toInt())
+            putInt(KEY_CICLOS_ATE_PAUSA_LONGA, ciclosAtePausaLonga.value ?: 4)
+            putBoolean(KEY_MODO_HIPERFOCO, ativarModoHiperfoco.value ?: false)
+            putBoolean(KEY_ALARME_SONORO, ativarAlarmeSonoro.value ?: true)
+            apply()
+        }
+    }
+
+    fun setConfiguracoes(focoMin: Int, curtaMin: Int, longaMin: Int, ciclos: Int, hiperfoco: Boolean, som: Boolean) {
+        if (estadoAtual.value != PomodoroState.PRONTO && estadoAtual.value != PomodoroState.PAUSADO) return
+
+        duracaoFocoMillis.value = TimeUnit.MINUTES.toMillis(focoMin.toLong())
+        duracaoPausaCurtaMillis.value = TimeUnit.MINUTES.toMillis(pausaCurtaMin.toLong())
+        duracaoPausaLongaMillis.value = TimeUnit.MINUTES.toMillis(longaMin.toLong())
+        ciclosAtePausaLonga.value = ciclos
+        ativarModoHiperfoco.value = hiperfoco
+        ativarAlarmeSonoro.value = som
+
+        salvarConfiguracoes()
+        appContext?.let { resetarParaEstadoInicial(it) }
+    }
+
+    private fun resetarParaEstadoInicial(context: Context) {
+        countDownTimer?.cancel(); countDownTimer = null
+        ciclosDeFocoCompletosNaSequencia = 0
+        _cicloFocoAtual.value = 0
+        _estadoAtual.value = PomodoroState.PRONTO
+        _tempoRestanteMillis.value = duracaoFocoMillis.value ?: TimeUnit.MINUTES.toMillis(25)
+        _tempoTotalCicloAtualMillis.value = duracaoFocoMillis.value ?: TimeUnit.MINUTES.toMillis(25)
+        millisRestantesAoPausar = 0
+        estadoAntesDePausar = PomodoroState.PRONTO
+        restaurarModoNaoPerturbe(context)
+        cancelarNotificacao(context)
+    }
+
+    private fun iniciarTimer(duracaoMillis: Long, estadoAlvo: PomodoroState, context: Context) {
+        if (estadoAlvo == PomodoroState.FOCO && (ativarModoHiperfoco.value == true)) {
+            ativarModoNaoPerturbe(context)
+        } else {
+            restaurarModoNaoPerturbe(context)
+        }
+
+        _tempoRestanteMillis.value = duracaoMillis
+        _tempoTotalCicloAtualMillis.value = duracaoMillis
+        _estadoAtual.value = estadoAlvo
+
+        countDownTimer?.cancel() // Garante que qualquer timer anterior seja cancelado
+        countDownTimer = object : CountDownTimer(duracaoMillis, 1000) {
+            override fun onTick(millisUntilFinished: Long) {
+                _tempoRestanteMillis.value = millisUntilFinished
+                // Notificação é atualizada pela Activity observando _tempoRestanteMillis
+            }
+            override fun onFinish() {
+                if (ativarAlarmeSonoro.value == true) {
+                    tocarSomAlarme(context)
+                }
+                avancarParaProximoEstado(context)
+            }
+        }.start()
+        // Atualizar notificação para o novo estado/tempo
+        val tempoFormatado = formatarMillisParaString(_tempoRestanteMillis.value ?: duracaoMillis)
+        mostrarOuAtualizarNotificacao(context, tempoFormatado)
+    }
+
+    private fun tocarSomAlarme(context: Context) {
+        // Placeholder para som, pois não posso adicionar R.raw.pomodoro_alarm
+        Log.d("PomodoroViewModel", "Alarme sonoro TOCARIA AGORA para estado: ${_estadoAtual.value}")
+        Toast.makeText(context, "Fim do ciclo: ${_estadoAtual.value}", Toast.LENGTH_SHORT).show()
+        // try {
+        //     mediaPlayer?.release() // Libera player anterior se houver
+        //     mediaPlayer = MediaPlayer.create(context, R.raw.pomodoro_alarm) // Substituir com som real
+        //     mediaPlayer?.setOnCompletionListener { mp -> mp.release() }
+        //     mediaPlayer?.start()
+        // } catch (e: Exception) {
+        //     Log.e("PomodoroViewModel", "Erro ao tocar som do alarme", e)
+        // }
+    }
+
+
+    private fun avancarParaProximoEstado(context: Context) {
+        val ciclosAteLonga = ciclosAtePausaLonga.value ?: 4
+        val duracaoFoco = duracaoFocoMillis.value ?: TimeUnit.MINUTES.toMillis(25)
+        val duracaoCurta = duracaoPausaCurtaMillis.value ?: TimeUnit.MINUTES.toMillis(5)
+        val duracaoLonga = duracaoPausaLongaMillis.value ?: TimeUnit.MINUTES.toMillis(15)
+
+        when (_estadoAtual.value) {
+            PomodoroState.FOCO -> {
+                restaurarModoNaoPerturbe(context)
+                ciclosDeFocoCompletosNaSequencia++
+                if (ciclosDeFocoCompletosNaSequencia >= ciclosAteLonga) {
+                    iniciarTimer(duracaoLonga, PomodoroState.PAUSA_LONGA, context)
+                    ciclosDeFocoCompletosNaSequencia = 0
+                } else {
+                    iniciarTimer(duracaoCurta, PomodoroState.PAUSA_CURTA, context)
+                }
+            }
+            PomodoroState.PAUSA_CURTA, PomodoroState.PAUSA_LONGA -> {
+                val cicloAtual = _cicloFocoAtual.value ?: 0
+                _cicloFocoAtual.value = cicloAtual + 1
+                if (_estadoAtual.value == PomodoroState.PAUSA_LONGA) {
+                     _cicloFocoAtual.value = 1
+                     ciclosDeFocoCompletosNaSequencia = 0
+                }
+                iniciarTimer(duracaoFoco, PomodoroState.FOCO, context)
+            }
+            else -> { resetarParaEstadoInicial(context) }
+        }
+    }
+
+    fun iniciarPausar(context: Context) {
+        when (_estadoAtual.value) {
+            PomodoroState.PRONTO -> {
+                _cicloFocoAtual.value = 1
+                ciclosDeFocoCompletosNaSequencia = 0
+                iniciarTimer(duracaoFocoMillis.value ?: TimeUnit.MINUTES.toMillis(25), PomodoroState.FOCO, context)
+            }
+            PomodoroState.FOCO, PomodoroState.PAUSA_CURTA, PomodoroState.PAUSA_LONGA -> {
+                estadoAntesDePausar = _estadoAtual.value!!
+                millisRestantesAoPausar = _tempoRestanteMillis.value ?: 0
+                countDownTimer?.cancel()
+                _estadoAtual.value = PomodoroState.PAUSADO
+                // Atualiza notificação para "Pausado"
+                val tempoFormatado = formatarMillisParaString(millisRestantesAoPausar)
+                mostrarOuAtualizarNotificacao(context, tempoFormatado)
+            }
+            PomodoroState.PAUSADO -> {
+                if (millisRestantesAoPausar > 0) {
+                    iniciarTimer(millisRestantesAoPausar, estadoAntesDePausar, context)
+                } else {
+                     _estadoAtual.value = estadoAntesDePausar
+                    avancarParaProximoEstado(context)
+                }
+                millisRestantesAoPausar = 0
+            }
+            null -> resetarParaEstadoInicial(context)
+        }
+    }
+
+    fun resetarCicloAtualOuPomodoro(context: Context) {
+        countDownTimer?.cancel()
+        if (_estadoAtual.value == PomodoroState.PRONTO) {
+            cancelarNotificacao(context) // Garante que notificação seja removida se estava pronto
+            return
+        }
+
+        val estadoParaResetar = if (_estadoAtual.value == PomodoroState.PAUSADO) estadoAntesDePausar else _estadoAtual.value
+
+        when (estadoParaResetar) {
+            PomodoroState.FOCO -> {
+                restaurarModoNaoPerturbe(context) // Garante restauração do DND
+                iniciarTimer(duracaoFocoMillis.value ?: TimeUnit.MINUTES.toMillis(25), PomodoroState.FOCO, context)
+            }
+            PomodoroState.PAUSA_CURTA -> iniciarTimer(duracaoPausaCurtaMillis.value ?: TimeUnit.MINUTES.toMillis(5), PomodoroState.PAUSA_CURTA, context)
+            PomodoroState.PAUSA_LONGA -> iniciarTimer(duracaoPausaLongaMillis.value ?: TimeUnit.MINUTES.toMillis(15), PomodoroState.PAUSA_LONGA, context)
+            else -> resetarParaEstadoInicial(context) // Inclui PRONTO e PAUSADO (que leva a PRONTO)
+        }
+    }
+
+    fun pularParaProximoCiclo(context: Context) {
+        if (_estadoAtual.value == PomodoroState.PRONTO) {
+            iniciarPausar(context)
+        } else {
+            countDownTimer?.cancel()
+            if (_estadoAtual.value == PomodoroState.FOCO || (_estadoAtual.value == PomodoroState.PAUSADO && estadoAntesDePausar == PomodoroState.FOCO)) {
+                 restaurarModoNaoPerturbe(context)
+            }
+            avancarParaProximoEstado(context)
+        }
+    }
+
+    private fun ativarModoNaoPerturbe(context: Context) {
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && notificationManager.isNotificationPolicyAccessGranted) {
+            if (filtroInterrupcaoAnterior == null) {
+                filtroInterrupcaoAnterior = notificationManager.currentInterruptionFilter
+            }
+            notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_PRIORITY)
+            dndAtivadoPeloViewModel = true
+            Log.d("PomodoroViewModel", "Modo Não Perturbe ATIVADO (filtro anterior: $filtroInterrupcaoAnterior).")
+        } else { Log.w("PomodoroViewModel", "Permissão para Modo Não Perturbe não concedida ou SDK < M.") }
+    }
+
+    private fun restaurarModoNaoPerturbe(context: Context) {
+        if (dndAtivadoPeloViewModel && filtroInterrupcaoAnterior != null) {
+            val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && notificationManager.isNotificationPolicyAccessGranted) {
+                notificationManager.setInterruptionFilter(filtroInterrupcaoAnterior!!)
+                Log.d("PomodoroViewModel", "Modo Não Perturbe RESTAURADO para $filtroInterrupcaoAnterior.")
+            } else { Log.w("PomodoroViewModel", "Não foi possível restaurar DND - permissão não concedida ou SDK < M.") }
+            filtroInterrupcaoAnterior = null
+            dndAtivadoPeloViewModel = false
+        }
+    }
+
+    fun mostrarOuAtualizarNotificacao(context: Context, tempoFormatado: String) {
+        if (!isTimerEffectivelyRunning() && _estadoAtual.value != PomodoroState.PAUSADO) {
+             cancelarNotificacao(context) // Cancela se não estiver rodando e não estiver explicitamente pausado
+             return
+        }
+
+        val intent = Intent(context, PomodoroActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK // Ou FLAG_ACTIVITY_SINGLE_TOP
+        }
+        val pendingIntentFlag = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT else PendingIntent.FLAG_UPDATE_CURRENT
+        val pendingIntent: PendingIntent = PendingIntent.getActivity(context, 0, intent, pendingIntentFlag)
+
+        val estadoStr = _estadoAtual.value?.name?.lowercase(Locale.getDefault())?.replaceFirstChar { it.titlecase(Locale.getDefault()) } ?: "Pomodoro"
+
+        val builder = NotificationCompat.Builder(context, POMODORO_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground) // TODO: Substituir por um ícone de timer/foco real
+            .setContentTitle("Pomodoro: $estadoStr")
+            .setContentText("Tempo: $tempoFormatado")
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .setOngoing(true) // Torna persistente enquanto o timer está ativo ou pausado
+            .setOnlyAlertOnce(true)
+            .setContentIntent(pendingIntent)
+            // TODO: Adicionar ações de Pausar/Resetar na notificação posteriormente
+
+        NotificationManagerCompat.from(context).notify(NOTIFICATION_ID, builder.build())
+    }
+
+    fun cancelarNotificacao(context: Context) {
+        NotificationManagerCompat.from(context).cancel(NOTIFICATION_ID)
+        Log.d("PomodoroViewModel", "Notificação Pomodoro cancelada.")
+    }
+
+    fun isTimerEffectivelyRunning(): Boolean = countDownTimer != null &&
+                                           (_estadoAtual.value != PomodoroState.PAUSADO &&
+                                            _estadoAtual.value != PomodoroState.PRONTO)
+
+
+    private fun formatarMillisParaString(millis: Long): String {
+        val minutos = TimeUnit.MILLISECONDS.toMinutes(millis)
+        val segundos = TimeUnit.MILLISECONDS.toSeconds(millis) % 60
+        return String.format("%02d:%02d", minutos, segundos)
+    }
+
+
+    override fun onCleared() {
+        super.onCleared()
+        countDownTimer?.cancel()
+        appContext?.let {
+            restaurarModoNaoPerturbe(it)
+            cancelarNotificacao(it)
+        }
+        mediaPlayer?.release() // Libera o mediaPlayer
+        mediaPlayer = null
+    }
+}

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_anotacoes.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_anotacoes.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.AnotacoesActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutAnotacoes"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarAnotacoes"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Minhas Anotações" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewAnotacoes"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/list_item_anotacao"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:clipToPadding="false"/>
+
+    <TextView
+        android:id="@+id/textViewListaVaziaAnotacoes"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nenhuma anotação encontrada."
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:visibility="gone"
+        app:layout_anchor="@id/recyclerViewAnotacoes"
+        app:layout_anchorGravity="center"
+        tools:visibility="visible"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabAdicionarAnotacao"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="Adicionar Nova Anotação"
+        app:srcCompat="@android:drawable/ic_input_add" /> <!-- Usar ícone melhor -->
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_dashboard.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_dashboard.xml
@@ -57,11 +57,24 @@
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="12dp">
+                    android:orientation="horizontal"
+                    android:paddingStart="0dp" android:paddingEnd="12dp" android:paddingTop="12dp" android:paddingBottom="12dp">
 
-                    <com.google.android.material.textview.MaterialTextView
-                        android:id="@+id/textViewHorarioProximoCompromisso"
+                    <View
+                        android:id="@+id/viewCorProximoCompromissoIndicador"
+                        android:layout_width="8dp"
+                        android:layout_height="match_parent"
+                        android:layout_marginEnd="12dp"
+                        tools:background="@color/colorPrimary"/>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:orientation="vertical">
+
+                        <com.google.android.material.textview.MaterialTextView
+                            android:id="@+id/textViewHorarioProximoCompromisso"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:textAppearance="?attr/textAppearanceSubtitle1"
@@ -99,6 +112,7 @@
                         android:textAppearance="?attr/textAppearanceBody1"
                         android:visibility="gone"
                         tools:visibility="visible"/>
+                    </LinearLayout>
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_detalhes_guia.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_detalhes_guia.xml
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.DetalhesGuiaActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutDetalhesGuia"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarDetalhesGuia"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Detalhes do Guia" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textViewTituloDetalhesGuia"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceHeadline5"
+                tools:text="Guia: Ciências - 1º Bim 2024"
+                android:layout_marginBottom="4dp"/>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textViewDisciplinaDetalhesGuia"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceSubtitle1"
+                tools:text="Disciplina: Ciências"
+                android:layout_marginBottom="4dp"/>
+
+            <com.google.android.material.textview.MaterialTextView
+                android:id="@+id/textViewBimestreAnoDetalhesGuia"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textAppearance="?attr/textAppearanceBody2"
+                tools:text="1º Bimestre - 2024"
+                android:layout_marginBottom="12dp"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonVerDocumentoAnexadoGuia"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Ver Documento Anexado"
+                android:visibility="gone"
+                tools:visibility="visible"
+                android:layout_marginBottom="16dp"/>
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="?android:attr/listDivider"
+                android:layout_marginBottom="16dp"/>
+
+
+            <com.google.android.material.textview.MaterialTextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Checklist de Habilidades/Conteúdos"
+                android:textAppearance="?attr/textAppearanceHeadline6"
+                android:layout_marginBottom="8dp"/>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerViewItensChecklist"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:minHeight="150dp"
+                tools:listitem="@layout/list_item_checklist_guia"
+                tools:itemCount="3"
+                android:nestedScrollingEnabled="false"
+                android:layout_marginBottom="8dp"/>
+
+            <TextView
+                android:id="@+id/textViewChecklistVazio"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="Nenhum item no checklist."
+                android:gravity="center"
+                android:visibility="gone"
+                tools:visibility="visible"
+                android:layout_marginBottom="16dp"/>
+
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical">
+
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/tilNovoItemChecklist"
+                    style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:hint="Novo item para o checklist">
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/editTextNovoItemChecklist"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textCapSentences"/>
+                </com.google.android.material.textfield.TextInputLayout>
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/buttonAdicionarItemChecklist"
+                    style="@style/Widget.MaterialComponents.Button.Icon"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="8dp"
+                    app:icon="@android:drawable/ic_input_add"
+                    tools:ignore="SpeakableTextPresentCheck" />
+            </LinearLayout>
+        </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_guias_de_aprendizagem.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_guias_de_aprendizagem.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.GuiasDeAprendizagemActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutGuias"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarGuias"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Guias de Aprendizagem" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewGuias"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/list_item_guia_de_aprendizagem"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:clipToPadding="false"/>
+
+    <TextView
+        android:id="@+id/textViewListaVaziaGuias"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nenhum guia de aprendizagem cadastrado."
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:visibility="gone"
+        app:layout_anchor="@id/recyclerViewGuias"
+        app:layout_anchorGravity="center"
+        tools:visibility="visible"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabAdicionarGuia"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="Adicionar Novo Guia de Aprendizagem"
+        app:srcCompat="@android:drawable/ic_input_add" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_main.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_main.xml
@@ -90,6 +90,50 @@
         android:layout_marginBottom="8dp"/>
 
     <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonGerenciarTemplatesPlanoAula"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Templates de Plano de Aula"
+        app:layout_constraintBottom_toTopOf="@id/buttonGerenciarGuias"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="8dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonGerenciarPlanosDeAula"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Planos de Aula"
+        app:layout_constraintBottom_toTopOf="@id/buttonVerDashboard"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="8dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonGerenciarTarefas"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Gerenciar Tarefas"
+        app:layout_constraintBottom_toTopOf="@id/buttonGerenciarTemplatesPlanoAula"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="8dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonGerenciarGuias"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Guias de Aprendizagem"
+        app:layout_constraintBottom_toTopOf="@id/buttonGerenciarPlanosDeAula"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="8dp"/>
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/buttonGerenciarEventos"
         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
         android:layout_width="0dp"
@@ -106,8 +150,20 @@
         android:layout_height="wrap_content"
         android:text="Gerenciar Turmas"
         style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        app:layout_constraintBottom_toTopOf="@id/buttonMinhasAnotacoes"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="8dp"/>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/buttonMinhasAnotacoes"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Minhas Anotações"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent" />
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginBottom="8dp"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_planos_de_aula_geral.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_planos_de_aula_geral.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.PlanosDeAulaGeralActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutPlanosDeAula"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarPlanosDeAula"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Planos de Aula" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewPlanosDeAula"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/list_item_plano_de_aula"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:clipToPadding="false"/>
+
+    <TextView
+        android:id="@+id/textViewListaVaziaPlanos"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nenhum plano de aula cadastrado."
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:visibility="gone"
+        app:layout_anchor="@id/recyclerViewPlanosDeAula"
+        app:layout_anchorGravity="center"
+        tools:visibility="visible"/>
+
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabAdicionarPlanoDeAula"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="Adicionar Novo Plano de Aula"
+        app:srcCompat="@android:drawable/ic_input_add" /> <!-- Usar ícone melhor -->
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_pomodoro.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_pomodoro.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.PomodoroActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutPomodoro"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarPomodoro"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Pomodoro" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        android:gravity="center"
+        android:padding="16dp"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewEstadoCicloPomodoro"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceHeadline5"
+            tools:text="Foco"
+            android:layout_marginBottom="8dp"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewTempoPomodoro"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="80sp"
+            android:textStyle="bold"
+            tools:text="24:58"
+            android:layout_marginBottom="8dp"/>
+
+        <ProgressBar
+            android:id="@+id/progressBarPomodoro"
+            style="?android:attr/progressBarStyleHorizontal"
+            android:layout_width="match_parent"
+            android:layout_height="12dp"
+            android:max="100"
+            tools:progress="50"
+            android:layout_marginStart="32dp"
+            android:layout_marginEnd="32dp"
+            android:layout_marginBottom="16dp"/>
+
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewNumeroCicloPomodoro"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            tools:text="Ciclo: 1/4"
+            android:layout_marginBottom="24dp"/>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center">
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonResetarPomodoro"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Resetar"
+                android:enabled="false"
+                android:layout_marginEnd="8dp"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonIniciarPausarPomodoro"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:minWidth="120dp"
+                tools:text="Pausar"
+                android:text="Iniciar"/>
+                <!-- app:icon="@drawable/ic_play_arrow" -->
+
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonPularCicloPomodoro"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Pular"
+                android:enabled="false"
+                android:layout_marginStart="8dp"/>
+        </LinearLayout>
+    </LinearLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/buttonConfigPomodoro"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="Configurações do Pomodoro"
+        app:srcCompat="@android:drawable/ic_menu_manage" /> <!-- Placeholder, usar ic_settings -->
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_tarefas.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_tarefas.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.TarefasActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutTarefas"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarTarefas"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Minhas Tarefas" />
+
+        <!-- Opcional: TabLayout para filtros Pendentes/Concluídas -->
+        <!--
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tabLayoutTarefasFiltro"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:tabMode="fixed"
+            app:tabGravity="fill"/>
+        -->
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewTarefas"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/list_item_tarefa"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:clipToPadding="false"/>
+
+    <TextView
+        android:id="@+id/textViewListaVaziaTarefas"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nenhuma tarefa encontrada."
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:visibility="gone"
+        app:layout_anchor="@id/recyclerViewTarefas"
+        app:layout_anchorGravity="center"
+        tools:visibility="visible"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabAdicionarTarefa"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="Adicionar Nova Tarefa"
+        app:srcCompat="@android:drawable/ic_input_add" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/activity_templates_plano_aula.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/activity_templates_plano_aula.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ui.activity.TemplatesPlanoAulaActivity">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBarLayoutTemplates"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarTemplates"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            app:title="Templates de Plano de Aula" />
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewTemplatesPlanoAula"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"
+        tools:listitem="@layout/list_item_template_plano_aula"
+        android:paddingTop="8dp"
+        android:paddingBottom="8dp"
+        android:clipToPadding="false"/>
+
+    <TextView
+        android:id="@+id/textViewListaVaziaTemplates"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Nenhum template cadastrado."
+        android:textAppearance="?attr/textAppearanceBody1"
+        android:visibility="gone"
+        app:layout_anchor="@id/recyclerViewTemplatesPlanoAula"
+        app:layout_anchorGravity="center"
+        tools:visibility="visible"/>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabAdicionarTemplate"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="Adicionar Novo Template"
+        app:srcCompat="@android:drawable/ic_input_add" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/dialog_config_pomodoro.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/dialog_config_pomodoro.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Configurações do Pomodoro"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center_horizontal"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilTempoFocoConfig"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Tempo de Foco (minutos)"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextTempoFocoConfig"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:maxLength="3"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilPausaCurtaConfig"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Pausa Curta (minutos)"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextPausaCurtaConfig"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:maxLength="3"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilPausaLongaConfig"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Pausa Longa (minutos)"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextPausaLongaConfig"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:maxLength="3"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilCiclosPausaLongaConfig"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Ciclos até Pausa Longa"
+            android:layout_marginBottom="16dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextCiclosPausaLongaConfig"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="number"
+                android:maxLength="2"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/switchModoHiperfocoConfig"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="Modo Hiperfoco (Pausas mais curtas)"
+            android:layout_marginBottom="8dp"/>
+
+        <com.google.android.material.switchmaterial.SwitchMaterial
+            android:id="@+id/switchAlarmeSonoroConfig"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:text="Alarme Sonoro ao final de cada ciclo"
+            android:layout_marginBottom="16dp"/>
+
+        <!-- Futuro: Opção para som contínuo (Ticking) -->
+        <!-- Futuro: Opção para auto-iniciar próximo ciclo -->
+
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancelarConfigPomodoro"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cancelar"
+                android:layout_marginEnd="8dp"/>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonSalvarConfigPomodoro"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Salvar"/>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_anotacao.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_anotacao.xml
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textViewFormularioAnotacaoTitulo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Nova Anotação"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center_horizontal"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilConteudoAnotacao"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Conteúdo*"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextConteudoAnotacao"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="5"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilTagsAnotacao"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Tags (ex: #ideia #lembrete)"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextTagsAnotacao"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="text"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="12dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cor:"
+                android:textAppearance="?attr/textAppearanceBody1"
+                android:layout_marginEnd="8dp"/>
+
+            <View
+                android:id="@+id/viewPreviewCorAnotacao"
+                android:layout_width="36dp"
+                android:layout_height="36dp"
+                android:background="@android:color/transparent"
+                android:layout_marginEnd="8dp"
+                android:clickable="true"
+                android:focusable="true"/>
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonEscolherCorAnotacao"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Escolher Cor"/>
+        </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Associar a (Opcional):"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:layout_marginStart="4dp"
+            android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerTurmaAnotacao"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="8dp"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layoutAlunoAnotacao"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Nome do Aluno (Opcional)"
+            android:visibility="visible"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextAlunoAnotacao"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textCapWords"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/buttonGravarVozAnotacao"
+            style="@style/Widget.MaterialComponents.Button.TextButton.Icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Gravar Voz (Em breve)"
+            app:icon="@android:drawable/ic_btn_speak_now"
+            android:layout_gravity="start"
+            android:layout_marginBottom="16dp"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancelarAnotacao"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cancelar"
+                android:layout_marginEnd="8dp"/>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonSalvarAnotacao"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Salvar"/>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_guia.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_guia.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textViewFormularioGuiaTitulo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Novo Guia de Aprendizagem"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center_horizontal"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilTituloGuiaForm"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Título do Guia (Opcional)"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextTituloGuiaForm"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textCapSentences"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Disciplina*" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerDisciplinaGuia"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="12dp"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="12dp">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilBimestreGuia"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:hint="Bimestre (ex: 1º Bimestre)">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editTextBimestreGuia"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textCapWords"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilAnoGuia"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+                android:layout_width="120dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:hint="Ano">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editTextAnoGuia"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"
+                    android:maxLength="4"/>
+            </com.google.android.material.textfield.TextInputLayout>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonAnexarDocumentoGuia"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Anexar Documento"/>
+            <TextView
+                android:id="@+id/textViewNomeAnexoGuia"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:ellipsize="middle"
+                android:maxLines="1"
+                tools:text="guia_de_aprendizagem.pdf"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancelarGuia"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cancelar"
+                android:layout_marginEnd="8dp"/>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonSalvarGuia"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Salvar"/>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_plano_de_aula.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_plano_de_aula.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textViewFormularioPlanoTitulo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Novo Plano de Aula"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center_horizontal"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilTituloPlano"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Título do Plano (Opcional)"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextTituloPlano"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textCapSentences"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Usar Template (Opcional)" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerSelecionarTemplatePlano"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="12dp"/>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Disciplina*" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerDisciplinaPlano"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="12dp"/>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Turma (Opcional)" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerTurmaPlano"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="12dp"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilDataAulaPlano"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Data da Aula (Opcional)"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextDataAulaPlano"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:focusable="false"
+                android:clickable="true"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilConteudoPlano"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Conteúdo / Observações"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextConteudoPlano"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="4"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonAnexarArquivoPlano"
+                style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Anexar Arquivo"/>
+            <TextView
+                android:id="@+id/textViewNomeAnexoPlano"
+                android:layout_width="0dp"
+                android:layout_weight="1"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:ellipsize="middle"
+                android:maxLines="1"
+                tools:text="documento_muito_longo_para_exibir_completo.pdf"/>
+        </LinearLayout>
+
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancelarPlano"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cancelar"
+                android:layout_marginEnd="8dp"/>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonSalvarPlano"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Salvar"/>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_tarefa.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_tarefa.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textViewFormularioTarefaTitulo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Nova Tarefa"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center_horizontal"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilDescricaoTarefa"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Descrição da Tarefa*"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextDescricaoTarefa"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="3"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Prazo (Opcional)" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:layout_marginBottom="12dp">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilPrazoDataTarefa"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:hint="Data"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editTextPrazoDataTarefa"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:focusable="false"
+                    android:clickable="true"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilPrazoHoraTarefa"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="0.7"
+                android:layout_marginStart="8dp"
+                android:hint="Hora"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editTextPrazoHoraTarefa"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:focusable="false"
+                    android:clickable="true"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            <ImageButton
+                android:id="@+id/buttonLimparPrazoTarefa"
+                android:layout_width="wrap_content"
+                android:layout_height="match_parent"
+                android:src="@android:drawable/ic_menu_close_clear_cancel"
+                android:contentDescription="Limpar Prazo"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                app:tint="?attr/colorControlNormal"
+                android:layout_gravity="center_vertical"/>
+        </LinearLayout>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Prioridade*" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerPrioridadeTarefa"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="12dp"/>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Disciplina (Opcional)" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerDisciplinaTarefa"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="12dp"/>
+
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:text="Turma (Opcional)" android:textAppearance="?attr/textAppearanceCaption" android:layout_marginStart="4dp" android:layout_marginBottom="2dp"/>
+        <Spinner
+            android:id="@+id/spinnerTurmaTarefa"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:layout_marginBottom="12dp"/> <!-- Reduzido marginBottom -->
+
+        <TextView
+            android:id="@+id/textViewLabelLembrete"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Lembrete (Requer Prazo)"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:layout_marginStart="4dp"
+            android:layout_marginBottom="2dp"/>
+
+        <Spinner
+            android:id="@+id/spinnerLembreteTarefa"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="48dp"
+            android:enabled="false"
+            android:layout_marginBottom="12dp"/>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Subtarefas (Checklist)"
+            android:textAppearance="?attr/textAppearanceSubtitle1"
+            android:layout_marginTop="16dp"
+            android:layout_marginBottom="8dp"/>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerViewSubtarefas"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:minHeight="100dp"
+            android:maxHeight="200dp"
+            android:nestedScrollingEnabled="false"
+            tools:listitem="@layout/list_item_subtarefa"
+            tools:itemCount="2"
+            android:layout_marginBottom="8dp"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="16dp">
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/tilNovaSubtarefa"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                app:hintEnabled="false"
+                style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense">
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/editTextNovaSubtarefa"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="Nova Subtarefa"/>
+            </com.google.android.material.textfield.TextInputLayout>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonAdicionarSubtarefa"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Add"
+                style="@style/Widget.MaterialComponents.Button.Icon"
+                app:icon="@android:drawable/ic_input_add"
+                android:layout_marginStart="8dp"
+                android:minWidth="0dp"
+                android:paddingStart="12dp"
+                android:paddingEnd="12dp"/>
+        </LinearLayout>
+
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancelarTarefa"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cancelar"
+                android:layout_marginEnd="8dp"/>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonSalvarTarefa"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Salvar"/>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_template_plano_aula.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/dialog_formulario_template_plano_aula.xml
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="20dp">
+
+        <TextView
+            android:id="@+id/textViewFormularioTemplateTitulo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Novo Template de Plano de Aula"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:layout_marginBottom="16dp"
+            android:layout_gravity="center_horizontal"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilNomeTemplateForm"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Nome do Template*"
+            android:layout_marginBottom="12dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextNomeTemplateForm"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textCapWords"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilCampoHabilidades"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Habilidades (Opcional)"
+            android:layout_marginBottom="8dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextCampoHabilidades"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="2"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilCampoRecursos"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Recursos (Opcional)"
+            android:layout_marginBottom="8dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextCampoRecursos"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="2"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilCampoMetodologia"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Metodologia/Estratégias (Opcional)"
+            android:layout_marginBottom="8dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextCampoMetodologia"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="3"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/tilCampoAvaliacao"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Avaliação (Opcional)"
+            android:layout_marginBottom="16dp">
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/editTextCampoAvaliacao"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textMultiLine|textCapSentences"
+                android:minLines="2"
+                android:gravity="top"/>
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- Para o campo 'outros_campos', a UI pode ser mais complexa (chave-valor)
+             ou simplesmente um campo de texto grande. Por simplicidade, omitindo por enquanto
+             ou pode ser incluído como um TextInputEditText genérico. -->
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="end">
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonCancelarTemplate"
+                style="@style/Widget.MaterialComponents.Button.TextButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Cancelar"
+                android:layout_marginEnd="8dp"/>
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/buttonSalvarTemplate"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Salvar"/>
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/AgendaFocoPEI/app/src/main/res/layout/list_item_anotacao.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/list_item_anotacao.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="4dp"
+    app:cardElevation="2dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp">
+
+        <View
+            android:id="@+id/viewCorAnotacaoItem"
+            android:layout_width="8dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:background="@android:color/holo_orange_light"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewConteudoAnotacaoItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textAppearance="?attr/textAppearanceBody1"
+            android:maxLines="4"
+            android:ellipsize="end"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/viewCorAnotacaoItem"
+            app:layout_constraintEnd_toStartOf="@+id/linearLayoutAnotacaoActions"
+            tools:text="Conteúdo da anotação que pode ser um pouco longo e ter múltiplas linhas para demonstração..." />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewTagsAnotacaoItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:textSize="12sp"
+            android:layout_marginTop="4dp"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@id/textViewConteudoAnotacaoItem"
+            app:layout_constraintStart_toStartOf="@id/textViewConteudoAnotacaoItem"
+            app:layout_constraintEnd_toEndOf="@id/textViewConteudoAnotacaoItem"
+            tools:text="#ideia #importante" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewAssociacaoAnotacaoItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:textSize="12sp"
+            android:layout_marginTop="2dp"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@id/textViewTagsAnotacaoItem"
+            app:layout_constraintStart_toStartOf="@id/textViewConteudoAnotacaoItem"
+            app:layout_constraintEnd_toEndOf="@id/textViewConteudoAnotacaoItem"
+            tools:text="Turma: 9A (Aluno: João)" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewDataModificacaoAnotacaoItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceOverline"
+            android:textSize="10sp"
+            tools:ignore="SmallSp"
+            android:layout_marginTop="4dp"
+            android:gravity="end"
+            app:layout_constraintTop_toBottomOf="@id/textViewAssociacaoAnotacaoItem"
+            app:layout_constraintStart_toStartOf="@id/textViewConteudoAnotacaoItem"
+            app:layout_constraintEnd_toEndOf="@id/textViewConteudoAnotacaoItem"
+            app:layout_constraintBottom_toBottomOf="parent"
+            tools:text="Modificado em: 10/06/24 15:30" />
+
+
+        <LinearLayout
+            android:id="@+id/linearLayoutAnotacaoActions"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintBottom_toBottomOf="@id/textViewConteudoAnotacaoItem"
+            android:layout_marginStart="8dp">
+
+            <ImageButton
+                android:id="@+id/buttonEditarAnotacaoItem"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="Editar Anotação"
+                app:srcCompat="@android:drawable/ic_menu_edit"
+                app:tint="?attr/colorPrimary" />
+
+            <ImageButton
+                android:id="@+id/buttonDeletarAnotacaoItem"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="Deletar Anotação"
+                app:srcCompat="@android:drawable/ic_menu_delete"
+                app:tint="?attr/colorError" />
+        </LinearLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/AgendaFocoPEI/app/src/main/res/layout/list_item_checklist_guia.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/list_item_checklist_guia.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingStart="16dp"
+    android:paddingEnd="8dp"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:background="?attr/selectableItemBackground">
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/checkBoxItemChecklist"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"/>
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/textViewDescricaoItemChecklist"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:textAppearance="?attr/textAppearanceBody1"
+        tools:text="Descrição do item do checklist que pode ser um pouco longa." />
+
+    <ImageButton
+        android:id="@+id/buttonDeletarItemChecklist"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="Deletar item do checklist"
+        android:src="@android:drawable/ic_menu_close_clear_cancel"
+        app:tint="?attr/colorControlNormal"
+        xmlns:app="http://schemas.android.com/apk/res-auto" />
+
+</LinearLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/list_item_guia_de_aprendizagem.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/list_item_guia_de_aprendizagem.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="4dp"
+    app:cardElevation="2dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp">
+
+        <View
+            android:id="@+id/viewCorGuia"
+            android:layout_width="8dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:background="@color/colorSecondary"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewTituloGuiaItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:textSize="18sp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/viewCorGuia"
+            app:layout_constraintEnd_toStartOf="@+id/buttonEditarGuia"
+            tools:text="Guia: Física - 3º Bim 2024" />
+            <!-- Opcional: Usar guia.tituloGuia se não nulo, senão gerar -->
+
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewProgressoChecklistGuia"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:layout_marginTop="4dp"
+            app:layout_constraintTop_toBottomOf="@id/textViewTituloGuiaItem"
+            app:layout_constraintStart_toStartOf="@id/textViewTituloGuiaItem"
+            tools:text="Checklist: 5/10" />
+
+        <ImageView
+            android:id="@+id/imageViewAnexoIconGuia"
+            android:layout_width="20dp"
+            android:layout_height="20dp"
+            app:srcCompat="@android:drawable/ic_menu_attachment"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@id/textViewProgressoChecklistGuia"
+            app:layout_constraintStart_toStartOf="@id/textViewTituloGuiaItem"
+            android:layout_marginTop="4dp"
+            app:tint="?android:attr/textColorSecondary"
+            android:contentDescription="Possui anexo" />
+
+
+        <ImageButton
+            android:id="@+id/buttonDeletarGuia"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Deletar Guia"
+            app:srcCompat="@android:drawable/ic_menu_delete"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:tint="?attr/colorError" />
+
+        <ImageButton
+            android:id="@+id/buttonEditarGuia"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Editar Guia"
+            app:srcCompat="@android:drawable/ic_menu_edit"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/buttonDeletarGuia"
+            app:tint="?attr/colorPrimary" />
+
+        <ImageButton
+            android:id="@+id/buttonDetalhesGuia"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Ver Detalhes do Guia"
+            app:srcCompat="@android:drawable/ic_menu_info_details"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:tint="?attr/colorControlNormal" />
+
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/AgendaFocoPEI/app/src/main/res/layout/list_item_plano_de_aula.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/list_item_plano_de_aula.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="4dp"
+    app:cardElevation="2dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp">
+
+        <View
+            android:id="@+id/viewCorIndicadorPlano"
+            android:layout_width="8dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:background="@color/colorPrimary"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewTituloPlanoItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="12dp"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            android:textSize="18sp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/viewCorIndicadorPlano"
+            app:layout_constraintEnd_toStartOf="@+id/buttonEditarPlano"
+            tools:text="Plano de Aula: Eletromagnetismo" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewDataPlanoItem"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            app:layout_constraintTop_toBottomOf="@id/textViewTituloPlanoItem"
+            app:layout_constraintStart_toStartOf="@id/textViewTituloPlanoItem"
+            tools:text="Data: 2024-08-15" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewDisciplinaPlanoItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceBody2"
+            android:layout_marginTop="4dp"
+            app:layout_constraintTop_toBottomOf="@id/textViewDataPlanoItem"
+            app:layout_constraintStart_toStartOf="@id/textViewTituloPlanoItem"
+            app:layout_constraintEnd_toEndOf="@id/textViewTituloPlanoItem"
+            tools:text="Disciplina: Física" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewTurmaPlanoItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceCaption"
+            app:layout_constraintTop_toBottomOf="@id/textViewDisciplinaPlanoItem"
+            app:layout_constraintStart_toStartOf="@id/textViewTituloPlanoItem"
+            app:layout_constraintEnd_toEndOf="@id/textViewTituloPlanoItem"
+            tools:text="Turma: 3A" />
+
+        <ImageView
+            android:id="@+id/imageViewAnexoIconPlanoItem"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            app:srcCompat="@android:drawable/ic_menu_attachment"
+            android:visibility="gone"
+            tools:visibility="visible"
+            app:layout_constraintTop_toBottomOf="@id/textViewTurmaPlanoItem"
+            app:layout_constraintStart_toStartOf="@id/textViewTituloPlanoItem"
+            android:layout_marginTop="4dp"
+            app:tint="?android:attr/textColorSecondary"
+            android:contentDescription="Possui anexo" />
+
+        <ImageButton
+            android:id="@+id/buttonDeletarPlano"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Deletar Plano de Aula"
+            app:srcCompat="@android:drawable/ic_menu_delete"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:tint="?attr/colorError" />
+
+        <ImageButton
+            android:id="@+id/buttonEditarPlano"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Editar Plano de Aula"
+            app:srcCompat="@android:drawable/ic_menu_edit"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/buttonDeletarPlano"
+            app:tint="?attr/colorPrimary" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/AgendaFocoPEI/app/src/main/res/layout/list_item_subtarefa.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/list_item_subtarefa.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:gravity="center_vertical"
+    android:paddingTop="4dp"
+    android:paddingBottom="4dp">
+
+    <com.google.android.material.checkbox.MaterialCheckBox
+        android:id="@+id/checkBoxSubtarefaConcluida"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:minWidth="0dp"
+        android:minHeight="48dp"/>
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/layoutDescricaoSubtarefa"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        app:hintEnabled="false"
+        style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox.Dense">
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/editTextDescricaoSubtarefaItem"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Descrição da Subtarefa"
+            android:inputType="textCapSentences"
+            android:maxLines="3"
+            android:textSize="14sp"/>
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <ImageButton
+        android:id="@+id/buttonDeletarSubtarefa"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:src="@android:drawable/ic_menu_delete"
+        android:background="?attr/selectableItemBackgroundBorderless"
+        android:contentDescription="Deletar Subtarefa"
+        app:tint="?attr/colorControlNormal"
+        android:padding="8dp"/>
+</LinearLayout>

--- a/AgendaFocoPEI/app/src/main/res/layout/list_item_tarefa.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/list_item_tarefa.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="4dp"
+    app:cardElevation="2dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="12dp">
+
+        <View
+            android:id="@+id/viewPrioridadeTarefa"
+            android:layout_width="8dp"
+            android:layout_height="0dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            tools:background="@android:color/holo_red_dark"/>
+
+        <com.google.android.material.checkbox.MaterialCheckBox
+            android:id="@+id/checkBoxTarefaConcluida"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/viewPrioridadeTarefa"
+            app:layout_constraintBottom_toBottomOf="parent"
+            android:minWidth="0dp"
+            android:minHeight="0dp"/>
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewTarefaDescricao"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:textAppearance="?attr/textAppearanceBody1"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/checkBoxTarefaConcluida"
+            app:layout_constraintEnd_toStartOf="@+id/buttonEditarTarefaItem"
+            tools:text="Descrição da Tarefa que pode ser um pouco longa para caber em uma linha só." />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewTarefaPrazo"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceCaption"
+            android:layout_marginTop="4dp"
+            app:layout_constraintTop_toBottomOf="@id/textViewTarefaDescricao"
+            app:layout_constraintStart_toStartOf="@id/textViewTarefaDescricao"
+            tools:text="Prazo: 25/12/2024 18:00" />
+
+        <com.google.android.material.chip.ChipGroup
+            android:id="@+id/chipGroupAssociacoesTarefa"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            app:chipSpacingHorizontal="4dp"
+            app:layout_constraintTop_toBottomOf="@id/textViewTarefaPrazo"
+            app:layout_constraintStart_toStartOf="@id/textViewTarefaDescricao"
+            app:layout_constraintEnd_toEndOf="@id/textViewTarefaDescricao"
+            app:layout_constraintBottom_toBottomOf="parent">
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipDisciplinaTarefa"
+                style="@style/Widget.MaterialComponents.Chip.Entry"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:text="Matemática"
+                tools:visibility="visible"/>
+
+            <com.google.android.material.chip.Chip
+                android:id="@+id/chipTurmaTarefa"
+                style="@style/Widget.MaterialComponents.Chip.Entry"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone"
+                tools:text="9A"
+                tools:visibility="visible"/>
+        </com.google.android.material.chip.ChipGroup>
+
+        <ImageButton
+            android:id="@+id/buttonEditarTarefaItem"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Editar Tarefa"
+            app:srcCompat="@android:drawable/ic_menu_edit"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:tint="?attr/colorPrimary" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/AgendaFocoPEI/app/src/main/res/layout/list_item_template_plano_aula.xml
+++ b/AgendaFocoPEI/app/src/main/res/layout/list_item_template_plano_aula.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginTop="4dp"
+    android:layout_marginEnd="8dp"
+    android:layout_marginBottom="4dp"
+    app:cardElevation="2dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/textViewNomeTemplateItem"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:textAppearance="?attr/textAppearanceListItem"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/buttonEditarTemplate"
+            tools:text="Template Padrão para Aulas Expositivas" />
+
+        <ImageButton
+            android:id="@+id/buttonDeletarTemplate"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Deletar Template"
+            app:srcCompat="@android:drawable/ic_menu_delete"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:tint="?attr/colorError" />
+
+        <ImageButton
+            android:id="@+id/buttonEditarTemplate"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="Editar Template"
+            app:srcCompat="@android:drawable/ic_menu_edit"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@id/buttonDeletarTemplate"
+            app:tint="?attr/colorPrimary" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/AgendaFocoPEI/app/src/main/res/values-night/colors.xml
+++ b/AgendaFocoPEI/app/src/main/res/values-night/colors.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Cores base para modo noturno -->
+    <color name="black">#FF000000</color> <!-- Mantido, mas geralmente não usado como fundo -->
+    <color name="white">#FFFFFFFF</color> <!-- Mantido para texto/ícones sobre fundos escuros -->
+
+    <!-- Cores da Marca - Tema Escuro -->
+    <color name="colorPrimary">#BB86FC</color> <!-- Roxo 200 (Material Design) -->
+    <color name="colorPrimaryVariant">#9962DD</color> <!-- Um tom um pouco mais escuro/dessaturado que o primary -->
+    <color name="colorOnPrimary">#000000</color> <!-- Preto (para contraste com roxo claro) -->
+
+    <color name="colorSecondary">#03DAC5</color> <!-- Teal 200 (Material Design - já é claro e vibrante) -->
+    <color name="colorSecondaryVariant">#018786</color> <!-- Teal 700 (Pode ser mantido ou ajustado) -->
+    <color name="colorOnSecondary">#000000</color> <!-- Preto (para contraste com teal claro) -->
+
+    <!-- Cores de Superfície e Fundo - Tema Escuro -->
+    <color name="android_colorBackground">#121212</color> <!-- Padrão Material para fundo escuro -->
+    <color name="colorSurface">#1E1E1E</color> <!-- Um pouco mais claro que o fundo, para cards, etc. -->
+    <!-- Ou use sobreposições de elevação:
+         Para Material 3, colorSurface é geralmente um tom neutro (ex: N10)
+         e as elevações adicionam um "tint" de colorPrimary.
+         Por simplicidade, vamos usar cores sólidas por enquanto.
+    -->
+    <color name="colorOnSurface">#E0E0E0</color> <!-- Branco com alta opacidade (ex: 87%) -->
+    <color name="colorOnBackground">#E0E0E0</color> <!-- Branco com alta opacidade -->
+
+    <!-- Cores de Erro - Tema Escuro -->
+    <color name="colorError">#CF6679</color> <!-- Vermelho claro do Material para temas escuros -->
+    <color name="colorOnError">#000000</color> <!-- Preto -->
+
+    <!-- Cores de Texto - Tema Escuro -->
+    <color name="textColorPrimaryDark">#DEFFFFFF</color> <!-- Branco 87% -->
+    <color name="textColorSecondaryDark">#B3FFFFFF</color> <!-- Branco 70% (Material sugere 60% para secondary, 38% para disabled) -->
+    <color name="textColorHintDark">#80FFFFFF</color> <!-- Branco 50% -->
+
+
+    <!-- Cores de Prioridade para Tarefas - Tema Escuro (ajustadas para melhor visibilidade) -->
+    <color name="prioridade_baixa">#81C784</color>  <!-- Verde 300 -->
+    <color name="prioridade_media">#FFB74D</color> <!-- Laranja 300 (em vez de Ambar para mais distinção) -->
+    <color name="prioridade_alta">#E57373</color>   <!-- Vermelho 300 -->
+
+    <!-- Cor Padrão Cinza Claro (para indicadores não definidos) - Tema Escuro -->
+    <color name="cor_padrao_cinza_claro">#424242</color> <!-- Cinza 800 (escuro) -->
+
+    <!-- Cor do Divisor - Tema Escuro -->
+    <color name="divider_color">#1FFFFFFF</color> <!-- Branco com 12% de opacidade -->
+</resources>

--- a/AgendaFocoPEI/app/src/main/res/values-night/themes.xml
+++ b/AgendaFocoPEI/app/src/main/res/values-night/themes.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Base application theme for night mode. -->
+    <style name="Theme.AgendaFocoPEI" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+        <!-- Cores da Marca -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryVariant">@color/colorPrimaryVariant</item>
+        <item name="colorOnPrimary">@color/colorOnPrimary</item>
+
+        <item name="colorSecondary">@color/colorSecondary</item>
+        <item name="colorSecondaryVariant">@color/colorSecondaryVariant</item>
+        <item name="colorOnSecondary">@color/colorOnSecondary</item>
+
+        <!-- Cores de Fundo e Superfície -->
+        <item name="android:colorBackground">@color/android_colorBackground</item>
+        <item name="colorSurface">@color/colorSurface</item>
+        <item name="colorOnBackground">@color/colorOnBackground</item>
+        <item name="colorOnSurface">@color/colorOnSurface</item>
+
+        <!-- Cores de Erro -->
+        <item name="colorError">@color/colorError</item>
+        <item name="colorOnError">@color/colorOnError</item>
+
+        <!-- Cores de Texto Principais -->
+        <!-- android:textColorPrimary é usado por muitos componentes Material para o texto principal -->
+        <item name="android:textColorPrimary">@color/textColorPrimaryDark</item>
+        <!-- android:textColorSecondary é usado para texto menos proeminente -->
+        <item name="android:textColorSecondary">@color/textColorSecondaryDark</item>
+        <item name="android:textColorHint">@color/textColorHintDark</item>
+
+        <!-- Cor da Barra de Status -->
+        <!-- Usar colorSurface para a barra de status em modo escuro é comum -->
+        <item name="android:statusBarColor">@color/colorSurface</item>
+        <!-- Ou, se quiser que seja igual à AppBar: ?attr/colorPrimaryVariant ou ?attr/colorPrimarySurface -->
+
+        <!-- Outras personalizações de tema para modo noturno podem vir aqui -->
+    </style>
+</resources>

--- a/AgendaFocoPEI/app/src/main/res/values/arrays.xml
+++ b/AgendaFocoPEI/app/src/main/res/values/arrays.xml
@@ -9,4 +9,21 @@
         <item>Sábado</item>
         <item>Domingo</item>
     </string-array>
+
+    <string-array name="prioridades_array">
+        <item>Baixa</item>
+        <item>Média</item>
+        <item>Alta</item>
+    </string-array>
+
+    <string-array name="opcoes_lembrete_array">
+        <item>Nenhum</item>
+        <item>Na hora do prazo</item>
+        <item>5 minutos antes</item>
+        <item>10 minutos antes</item>
+        <item>30 minutos antes</item>
+        <item>1 hora antes</item>
+        <item>2 horas antes</item>
+        <item>1 dia antes</item>
+    </string-array>
 </resources>

--- a/AgendaFocoPEI/app/src/main/res/values/colors.xml
+++ b/AgendaFocoPEI/app/src/main/res/values/colors.xml
@@ -1,11 +1,41 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- Cores base -->
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
 
-    <!-- Material Theme Colors (Exemplos, podem ser customizados no themes.xml) -->
-    <color name="colorPrimary">#FF6200EE</color> <!-- Exemplo: Purple 500 -->
-    <color name="colorPrimaryVariant">#FF3700B3</color> <!-- Exemplo: Purple 700 -->
-    <color name="colorSecondary">#FF03DAC5</color> <!-- Exemplo: Teal 200 -->
-    <color name="colorSecondaryVariant">#FF018786</color> <!-- Exemplo: Teal 700 -->
+    <!-- Cores da Marca - Tema Claro (Padrão Material Design) -->
+    <color name="colorPrimary">#FF6200EE</color> <!-- Purple 500 -->
+    <color name="colorPrimaryVariant">#FF3700B3</color> <!-- Purple 700 -->
+    <color name="colorOnPrimary">#FFFFFFFF</color> <!-- Branco -->
+
+    <color name="colorSecondary">#FF03DAC5</color> <!-- Teal 200 -->
+    <color name="colorSecondaryVariant">#FF018786</color> <!-- Teal 700 -->
+    <color name="colorOnSecondary">#FF000000</color> <!-- Preto -->
+
+    <!-- Cores de Fundo e Superfície - Tema Claro -->
+    <color name="android_colorBackground">#FFFFFFFF</color> <!-- Branco -->
+    <color name="colorSurface">#FFFFFFFF</color> <!-- Branco -->
+    <color name="colorOnBackground">#FF000000</color> <!-- Preto -->
+    <color name="colorOnSurface">#FF000000</color> <!-- Preto -->
+
+    <!-- Cores de Erro - Tema Claro -->
+    <color name="colorError">#B00020</color> <!-- Vermelho Erro Padrão Material -->
+    <color name="colorOnError">#FFFFFFFF</color> <!-- Branco -->
+
+    <!-- Cores de Texto Principais - Tema Claro -->
+    <color name="textColorPrimaryLight">#DE000000</color> <!-- Preto 87% -->
+    <color name="textColorSecondaryLight">#8A000000</color> <!-- Preto 54% -->
+    <color name="textColorHintLight">#61000000</color> <!-- Preto 38% -->
+
+    <!-- Cores de Prioridade para Tarefas - Tema Claro -->
+    <color name="prioridade_baixa">#4CAF50</color> <!-- Verde 500 -->
+    <color name="prioridade_media">#FFC107</color> <!-- Ambar 500 -->
+    <color name="prioridade_alta">#F44336</color>  <!-- Vermelho 500 -->
+
+    <!-- Cor Padrão Cinza Claro (para indicadores não definidos) - Tema Claro -->
+    <color name="cor_padrao_cinza_claro">#FFE0E0E0</color> <!-- Cinza 300 -->
+
+    <!-- Cor do Divisor - Tema Claro -->
+    <color name="divider_color">#1F000000</color> <!-- Preto com 12% de opacidade -->
 </resources>

--- a/AgendaFocoPEI/app/src/main/res/values/themes.xml
+++ b/AgendaFocoPEI/app/src/main/res/values/themes.xml
@@ -2,25 +2,65 @@
 <resources>
     <!-- Base application theme. -->
     <style name="Theme.AgendaFocoPEI" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
+        <!-- Cores da Marca -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryVariant">@color/colorPrimaryVariant</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
+        <item name="colorOnPrimary">@color/colorOnPrimary</item>
+
         <item name="colorSecondary">@color/colorSecondary</item>
         <item name="colorSecondaryVariant">@color/colorSecondaryVariant</item>
-        <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
+        <item name="colorOnSecondary">@color/colorOnSecondary</item>
+
+        <!-- Cores de Fundo e Superfície -->
+        <item name="android:colorBackground">@color/android_colorBackground</item>
+        <item name="colorSurface">@color/colorSurface</item>
+        <item name="colorOnBackground">@color/colorOnBackground</item>
+        <item name="colorOnSurface">@color/colorOnSurface</item>
+
+        <!-- Cores de Erro -->
+        <item name="colorError">@color/colorError</item>
+        <item name="colorOnError">@color/colorOnError</item>
+
+        <!-- Cores de Texto Principais -->
+        <item name="android:textColorPrimary">@color/textColorPrimaryLight</item>
+        <item name="android:textColorSecondary">@color/textColorSecondaryLight</item>
+        <item name="android:textColorHint">@color/textColorHintLight</item>
+
+        <!-- Cor da Barra de Status -->
         <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
+
         <!-- Customize your theme here. -->
     </style>
 
-    <!-- Tema para modo noturno, se necessário no futuro -->
-    <!-- <style name="Theme.AgendaFocoPEI.NoActionBar">
-        <item name="windowActionBar">false</item>
-        <item name="windowNoTitle">true</item>
-    </style> -->
+    <!-- Opcional: Se precisar de um tema NoActionBar para algumas Activities -->
+    <style name="Theme.AgendaFocoPEI.NoActionBar" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Cores da Marca -->
+        <item name="colorPrimary">@color/colorPrimary</item>
+        <item name="colorPrimaryVariant">@color/colorPrimaryVariant</item>
+        <item name="colorOnPrimary">@color/colorOnPrimary</item>
 
-    <!-- <style name="Theme.AgendaFocoPEI.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" /> -->
-    <!-- <style name="Theme.AgendaFocoPEI.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" /> -->
+        <item name="colorSecondary">@color/colorSecondary</item>
+        <item name="colorSecondaryVariant">@color/colorSecondaryVariant</item>
+        <item name="colorOnSecondary">@color/colorOnSecondary</item>
+
+        <!-- Cores de Fundo e Superfície -->
+        <item name="android:colorBackground">@color/android_colorBackground</item>
+        <item name="colorSurface">@color/colorSurface</item>
+        <item name="colorOnBackground">@color/colorOnBackground</item>
+        <item name="colorOnSurface">@color/colorOnSurface</item>
+
+        <!-- Cores de Erro -->
+        <item name="colorError">@color/colorError</item>
+        <item name="colorOnError">@color/colorOnError</item>
+
+        <!-- Cores de Texto Principais -->
+        <item name="android:textColorPrimary">@color/textColorPrimaryLight</item>
+        <item name="android:textColorSecondary">@color/textColorSecondaryLight</item>
+        <item name="android:textColorHint">@color/textColorHintLight</item>
+
+        <!-- Cor da Barra de Status -->
+        <item name="android:statusBarColor">@color/colorSurface</item>
+        <!-- Ou ?attr/colorPrimaryVariant -->
+    </style>
+
 </resources>

--- a/app/src/androidTest/java/com/agendafocopei/data/AnotacaoDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/AnotacaoDaoTest.kt
@@ -1,0 +1,194 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import android.graphics.Color
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class AnotacaoDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var anotacaoDao: AnotacaoDao
+    private lateinit var turmaDao: TurmaDao
+
+    private var t1Id: Int = 0
+    private var t2Id: Int = 0
+
+    @Before
+    fun createDb() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .fallbackToDestructiveMigration()
+            .build()
+        anotacaoDao = db.anotacaoDao()
+        turmaDao = db.turmaDao()
+
+        val turma1 = Turma(nome = "Anot Turma A", cor = Color.CYAN)
+        val turma2 = Turma(nome = "Anot Turma B", cor = Color.MAGENTA)
+        t1Id = turmaDao.inserir(turma1).toInt()
+        t2Id = turmaDao.inserir(turma2).toInt()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirAnotacao_eBuscarPorId_retornaAnotacaoCorreta() = runBlocking {
+        val currentTime = System.currentTimeMillis()
+        val anotacao = Anotacao(
+            conteudo = "Conteúdo da anotação 1",
+            dataCriacao = currentTime,
+            dataModificacao = currentTime,
+            cor = Color.YELLOW,
+            turmaId = t1Id,
+            alunoNome = "Aluno Teste",
+            tagsString = "#teste #importante"
+        )
+        val id = anotacaoDao.inserir(anotacao)
+        val buscada = anotacaoDao.buscarPorId(id.toInt())
+        assertNotNull(buscada)
+        assertEquals("Conteúdo da anotação 1", buscada?.conteudo)
+        assertEquals(currentTime, buscada?.dataCriacao)
+        assertEquals(Color.YELLOW, buscada?.cor)
+        assertEquals(t1Id, buscada?.turmaId)
+        assertEquals("Aluno Teste", buscada?.alunoNome)
+        assertEquals("#teste #importante", buscada?.tagsString)
+    }
+
+    @Test
+    fun buscarTodas_retornaListaOrdenadaPorDataModificacao() = runBlocking {
+        val now = System.currentTimeMillis()
+        anotacaoDao.inserir(Anotacao(conteudo = "Anot 2", dataModificacao = now - 1000, turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "Anot 1", dataModificacao = now, turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "Anot 3", dataModificacao = now - 500, turmaId = null))
+
+        val todas = anotacaoDao.buscarTodas().first()
+        assertEquals(3, todas.size)
+        assertEquals("Anot 1", todas[0].conteudo) // Mais recente
+        assertEquals("Anot 3", todas[1].conteudo)
+        assertEquals("Anot 2", todas[2].conteudo)
+    }
+
+    @Test
+    fun buscarPorTurmaId_retornaApenasAnotacoesDaTurmaCorreta() = runBlocking {
+        anotacaoDao.inserir(Anotacao(conteudo = "A1 T1", turmaId = t1Id))
+        anotacaoDao.inserir(Anotacao(conteudo = "A2 T2", turmaId = t2Id))
+        anotacaoDao.inserir(Anotacao(conteudo = "A3 T1", turmaId = t1Id))
+
+        val anotacoesT1 = anotacaoDao.buscarPorTurmaId(t1Id).first()
+        assertEquals(2, anotacoesT1.size)
+        assertTrue(anotacoesT1.all { it.turmaId == t1Id })
+
+        val anotacoesT2 = anotacaoDao.buscarPorTurmaId(t2Id).first()
+        assertEquals(1, anotacoesT2.size)
+        assertEquals("A2 T2", anotacoesT2[0].conteudo)
+    }
+
+    @Test
+    fun buscarPorTag_encontraAnotacoesComTagCorreta() = runBlocking {
+        anotacaoDao.inserir(Anotacao(conteudo = "C1", tagsString = "#ideia #projeto", turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "C2", tagsString = "#lembrete", turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "C3", tagsString = "#projeto #final", turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "C4", tagsString = "sem tag aqui", turmaId = null))
+
+        var porTag = anotacaoDao.buscarPorTag("%#projeto%").first()
+        assertEquals(2, porTag.size)
+        assertTrue(porTag.any { it.conteudo == "C1" })
+        assertTrue(porTag.any { it.conteudo == "C3" })
+
+        porTag = anotacaoDao.buscarPorTag("%#ideia%").first()
+        assertEquals(1, porTag.size)
+        assertEquals("C1", porTag[0].conteudo)
+
+        porTag = anotacaoDao.buscarPorTag("%#final%").first()
+        assertEquals(1, porTag.size)
+        assertEquals("C3", porTag[0].conteudo)
+    }
+
+    @Test
+    fun buscarPorTag_naoEncontraAnotacoesSemTagOuComTagDiferente() = runBlocking {
+        anotacaoDao.inserir(Anotacao(conteudo = "C1", tagsString = "#ideia", turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "C2", tagsString = null, turmaId = null))
+
+        val porTag = anotacaoDao.buscarPorTag("%#naoexiste%").first()
+        assertTrue(porTag.isEmpty())
+    }
+
+    @Test
+    fun buscarPorConteudo_encontraAnotacoesComTextoCorreto() = runBlocking {
+        anotacaoDao.inserir(Anotacao(conteudo = "Este é um teste de conteúdo.", turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "Outro conteúdo para teste.", turmaId = null))
+        anotacaoDao.inserir(Anotacao(conteudo = "Nada a ver.", turmaId = null))
+
+        val porConteudo = anotacaoDao.buscarPorConteudo("%teste%").first()
+        assertEquals(2, porConteudo.size)
+        assertTrue(porConteudo.any { it.conteudo.contains("Este é um teste")})
+        assertTrue(porConteudo.any { it.conteudo.contains("Outro conteúdo para teste")})
+    }
+
+
+    @Test
+    fun atualizarAnotacao_refleteMudancas() = runBlocking {
+        val anot = Anotacao(conteudo = "Original", cor = Color.RED, tagsString = "#old", turmaId = null)
+        val id = anotacaoDao.inserir(anot).toInt()
+
+        val paraAtualizar = anotacaoDao.buscarPorId(id)!!.copy(
+            conteudo = "Atualizado",
+            cor = Color.BLUE,
+            tagsString = "#new",
+            dataModificacao = System.currentTimeMillis() + 1000 // Garante que a data de modificação mude
+        )
+        anotacaoDao.atualizar(paraAtualizar)
+
+        val atualizada = anotacaoDao.buscarPorId(id)!!
+        assertEquals("Atualizado", atualizada.conteudo)
+        assertEquals(Color.BLUE, atualizada.cor)
+        assertEquals("#new", atualizada.tagsString)
+        assertTrue(atualizada.dataModificacao > anot.dataModificacao)
+    }
+
+    @Test
+    fun deletarAnotacao_naoDeveSerEncontrada() = runBlocking {
+        val anot = Anotacao(conteudo = "Para Deletar", turmaId = null)
+        val id = anotacaoDao.inserir(anot).toInt()
+        val paraDeletar = anotacaoDao.buscarPorId(id)!!
+        anotacaoDao.deletar(paraDeletar)
+        assertNull(anotacaoDao.buscarPorId(id))
+    }
+
+    @Test
+    fun deleteById_anotacaoNaoDeveSerEncontrada() = runBlocking {
+        val anot = Anotacao(conteudo = "Para Deletar por ID", turmaId = null)
+        val id = anotacaoDao.inserir(anot).toInt()
+        anotacaoDao.deleteById(id)
+        assertNull(anotacaoDao.buscarPorId(id))
+    }
+
+
+    @Test
+    fun onDeleteSetNull_turmaDeletada_anotacaoTurmaIdEhNull() = runBlocking {
+        val anot = Anotacao(conteudo = "Anotação com Turma", turmaId = t1Id)
+        val id = anotacaoDao.inserir(anot).toInt()
+
+        val turmaParaDeletar = turmaDao.buscarPorId(t1Id)!!
+        turmaDao.deletar(turmaParaDeletar) // onDelete = SET_NULL
+
+        val anotacaoAtualizada = anotacaoDao.buscarPorId(id)
+        assertNotNull(anotacaoAtualizada)
+        assertNull(anotacaoAtualizada?.turmaId)
+    }
+}

--- a/app/src/androidTest/java/com/agendafocopei/data/EventoDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/EventoDaoTest.kt
@@ -1,0 +1,200 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import android.graphics.Color
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class EventoDaoTest { // Nome da classe correto
+
+    private lateinit var db: AppDatabase
+    private lateinit var eventoDao: EventoDao // DAO correto
+
+    private val queryDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .build()
+        eventoDao = db.eventoDao() // Usar o DAO correto
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirEvento_comDataEspecifica_eBuscarPorId_retornaCorretamente() = runBlocking {
+        val dataCal = Calendar.getInstance().apply { set(2024, Calendar.JULY, 20) }
+        val dataStr = queryDateFormat.format(dataCal.time)
+        val evento = Evento(
+            nomeEvento = "Aniversário",
+            diaDaSemana = dataCal.get(Calendar.DAY_OF_WEEK), // Armazenar o dia da semana da data específica
+            horaInicio = "19:00",
+            horaFim = "23:00",
+            salaLocal = "Casa",
+            cor = Color.MAGENTA,
+            observacoes = "Festa!",
+            dataEspecifica = dataStr
+        )
+        val id = eventoDao.inserir(evento)
+        val recuperado = eventoDao.buscarPorId(id.toInt())
+        assertNotNull(recuperado)
+        assertEquals(dataStr, recuperado?.dataEspecifica)
+        assertEquals("Aniversário", recuperado?.nomeEvento)
+    }
+
+    @Test
+    fun inserirEvento_semDataEspecifica_eBuscarPorId_retornaCorretamente() = runBlocking {
+        val evento = Evento(
+            nomeEvento = "Reunião Semanal",
+            diaDaSemana = Calendar.MONDAY,
+            horaInicio = "10:00",
+            horaFim = "11:00",
+            salaLocal = "Sala A",
+            cor = Color.BLUE,
+            observacoes = "Pauta principal",
+            dataEspecifica = null
+        )
+        val id = eventoDao.inserir(evento)
+        val recuperado = eventoDao.buscarPorId(id.toInt())
+        assertNotNull(recuperado)
+        assertNull(recuperado?.dataEspecifica)
+        assertEquals(Calendar.MONDAY, recuperado?.diaDaSemana)
+        assertEquals("Reunião Semanal", recuperado?.nomeEvento)
+    }
+
+    @Test
+    fun atualizarEvento_deRecorrenteParaUnico_eViceVersa() = runBlocking {
+        // 1. Insere como recorrente
+        var evento = Evento(nomeEvento = "Yoga", diaDaSemana = Calendar.WEDNESDAY, horaInicio = "07:00", horaFim = "08:00", salaLocal = "Estúdio", cor = Color.GREEN, observacoes = null, dataEspecifica = null)
+        val id = eventoDao.inserir(evento)
+
+        // 2. Atualiza para único
+        val dataUnicaCal = Calendar.getInstance().apply { set(2024, Calendar.AUGUST, 14) } // Uma quarta-feira
+        val dataUnicaStr = queryDateFormat.format(dataUnicaCal.time)
+        val eventoParaAtualizarUnico = eventoDao.buscarPorId(id.toInt())!!.copy(
+            dataEspecifica = dataUnicaStr,
+            diaDaSemana = dataUnicaCal.get(Calendar.DAY_OF_WEEK) // Atualiza dia da semana para consistência
+        )
+        eventoDao.atualizar(eventoParaAtualizarUnico)
+        var recuperado = eventoDao.buscarPorId(id.toInt())
+        assertNotNull(recuperado)
+        assertEquals(dataUnicaStr, recuperado?.dataEspecifica)
+        assertEquals(Calendar.WEDNESDAY, recuperado?.diaDaSemana)
+
+        // 3. Atualiza de volta para recorrente
+        val eventoParaAtualizarRecorrente = recuperado!!.copy(dataEspecifica = null, diaDaSemana = Calendar.FRIDAY)
+        eventoDao.atualizar(eventoParaAtualizarRecorrente)
+        recuperado = eventoDao.buscarPorId(id.toInt())
+        assertNotNull(recuperado)
+        assertNull(recuperado?.dataEspecifica)
+        assertEquals(Calendar.FRIDAY, recuperado?.diaDaSemana)
+    }
+
+
+    @Test
+    fun buscarEventosParaData_retornaEventosUnicosERecorrentesCorretos() = runBlocking {
+        val calSegunda = Calendar.getInstance().apply { set(2024, Calendar.JULY, 15) } // Uma segunda-feira
+        val dataSegundaStr = queryDateFormat.format(calSegunda.time)
+        val diaSemanaSegunda = calSegunda.get(Calendar.DAY_OF_WEEK) // Deve ser Calendar.MONDAY
+
+        val calTerca = Calendar.getInstance().apply { set(2024, Calendar.JULY, 16) } // Uma terça-feira
+        val dataTercaStr = queryDateFormat.format(calTerca.time)
+        val diaSemanaTerca = calTerca.get(Calendar.DAY_OF_WEEK) // Deve ser Calendar.TUESDAY
+
+        // Eventos
+        eventoDao.inserir(Evento(nomeEvento = "Recorrente Seg", diaDaSemana = Calendar.MONDAY, horaInicio = "10:00", horaFim = "11:00", salaLocal = null, cor = null, observacoes = null, dataEspecifica = null))
+        eventoDao.inserir(Evento(nomeEvento = "Unico Seg Data", diaDaSemana = diaSemanaSegunda, horaInicio = "14:00", horaFim = "15:00", salaLocal = null, cor = null, observacoes = null, dataEspecifica = dataSegundaStr))
+        eventoDao.inserir(Evento(nomeEvento = "Unico Ter Data", diaDaSemana = diaSemanaTerca, horaInicio = "16:00", horaFim = "17:00", salaLocal = null, cor = null, observacoes = null, dataEspecifica = dataTercaStr))
+        eventoDao.inserir(Evento(nomeEvento = "Recorrente Ter", diaDaSemana = Calendar.TUESDAY, horaInicio = "09:00", horaFim = "10:00", salaLocal = null, cor = null, observacoes = null, dataEspecifica = null))
+
+        // Teste 1: Para segunda-feira específica
+        var eventos = eventoDao.buscarEventosParaData(diaSemanaSegunda, dataSegundaStr).first()
+        assertEquals(2, eventos.size)
+        assertTrue(eventos.any { it.nomeEvento == "Recorrente Seg" })
+        assertTrue(eventos.any { it.nomeEvento == "Unico Seg Data" })
+
+        // Teste 2: Para terça-feira específica
+        eventos = eventoDao.buscarEventosParaData(diaSemanaTerca, dataTercaStr).first()
+        assertEquals(2, eventos.size)
+        assertTrue(eventos.any { it.nomeEvento == "Recorrente Ter" })
+        assertTrue(eventos.any { it.nomeEvento == "Unico Ter Data" })
+
+        // Teste 3: Para uma quarta-feira específica, onde não há eventos únicos, mas pode haver recorrentes de quarta
+        val calQuarta = Calendar.getInstance().apply { set(2024, Calendar.JULY, 17) }
+        val dataQuartaStr = queryDateFormat.format(calQuarta.time)
+        val diaSemanaQuarta = calQuarta.get(Calendar.DAY_OF_WEEK)
+        eventoDao.inserir(Evento(nomeEvento = "Recorrente Qua", diaDaSemana = Calendar.WEDNESDAY, horaInicio = "11:00", horaFim = "12:00", salaLocal = null, cor = null, observacoes = null, dataEspecifica = null))
+
+        eventos = eventoDao.buscarEventosParaData(diaSemanaQuarta, dataQuartaStr).first()
+        assertEquals(1, eventos.size)
+        assertEquals("Recorrente Qua", eventos[0].nomeEvento)
+
+        // Teste 4: Para dataSegundaStr, mas passando um diaDaSemana que não é segunda (ex: domingo)
+        // Deve retornar apenas o evento único daquela data.
+        eventos = eventoDao.buscarEventosParaData(Calendar.SUNDAY, dataSegundaStr).first()
+        assertEquals(1, eventos.size)
+        assertEquals("Unico Seg Data", eventos[0].nomeEvento)
+    }
+
+    @Test
+    fun buscarProximoEventoParaData_consideraUnicosERecorrentes() = runBlocking {
+        val calSegunda = Calendar.getInstance().apply { set(2024, Calendar.JULY, 15) }
+        val dataSegundaStr = queryDateFormat.format(calSegunda.time)
+        val diaSemanaSegunda = calSegunda.get(Calendar.DAY_OF_WEEK)
+        val horaAtual = "09:00"
+
+        // Eventos
+        eventoDao.inserir(Evento(nomeEvento = "Passou Recorrente Seg", diaDaSemana = Calendar.MONDAY, horaInicio = "08:00", horaFim = "08:30", dataEspecifica = null, salaLocal = null, cor = null, observacoes = null))
+        eventoDao.inserir(Evento(nomeEvento = "Passou Unico Seg", diaDaSemana = diaSemanaSegunda, horaInicio = "08:30", horaFim = "08:45", dataEspecifica = dataSegundaStr, salaLocal = null, cor = null, observacoes = null))
+
+        eventoDao.inserir(Evento(nomeEvento = "Proximo Recorrente Seg", diaDaSemana = Calendar.MONDAY, horaInicio = "10:00", horaFim = "11:00", dataEspecifica = null, salaLocal = null, cor = null, observacoes = null))
+        eventoDao.inserir(Evento(nomeEvento = "Proximo Unico Seg", diaDaSemana = diaSemanaSegunda, horaInicio = "09:30", horaFim = "09:45", dataEspecifica = dataSegundaStr, salaLocal = null, cor = null, observacoes = null)) // Este deve ser o próximo
+        eventoDao.inserir(Evento(nomeEvento = "Mais Tarde Unico Seg", diaDaSemana = diaSemanaSegunda, horaInicio = "12:00", horaFim = "13:00", dataEspecifica = dataSegundaStr, salaLocal = null, cor = null, observacoes = null))
+        eventoDao.inserir(Evento(nomeEvento = "Outro Dia Unico", diaDaSemana = Calendar.TUESDAY, horaInicio = "09:15", horaFim = "09:45", dataEspecifica = queryDateFormat.format(Calendar.getInstance().apply{add(Calendar.DAY_OF_YEAR, 1)}.time ), salaLocal = null, cor = null, observacoes = null))
+
+
+        val proximo = eventoDao.buscarProximoEventoParaData(diaSemanaSegunda, dataSegundaStr, horaAtual)
+        assertNotNull(proximo)
+        assertEquals("Proximo Unico Seg", proximo?.nomeEvento)
+        assertEquals("09:30", proximo?.horaInicio)
+    }
+
+    @Test
+    fun buscarProximoEventoParaData_proximoEhRecorrente() = runBlocking {
+        val calSegunda = Calendar.getInstance().apply { set(2024, Calendar.JULY, 15) }
+        val dataSegundaStr = queryDateFormat.format(calSegunda.time)
+        val diaSemanaSegunda = calSegunda.get(Calendar.DAY_OF_WEEK)
+        val horaAtual = "09:00"
+
+        eventoDao.inserir(Evento(nomeEvento = "Proximo Recorrente Seg", diaDaSemana = Calendar.MONDAY, horaInicio = "09:15", horaFim = "10:15", dataEspecifica = null, salaLocal = null, cor = null, observacoes = null)) // Este é o próximo
+        eventoDao.inserir(Evento(nomeEvento = "Mais Tarde Unico Seg", diaDaSemana = diaSemanaSegunda, horaInicio = "10:00", horaFim = "11:00", dataEspecifica = dataSegundaStr, salaLocal = null, cor = null, observacoes = null))
+
+        val proximo = eventoDao.buscarProximoEventoParaData(diaSemanaSegunda, dataSegundaStr, horaAtual)
+        assertNotNull(proximo)
+        assertEquals("Proximo Recorrente Seg", proximo?.nomeEvento)
+        assertEquals("09:15", proximo?.horaInicio)
+        assertNull(proximo?.dataEspecifica)
+    }
+
+    // Testes CRUD básicos já existentes (inserir, atualizar, deletar, buscarTodos, buscarPorId, deleteById)
+    // são mantidos e devem funcionar com a entidade Evento.
+    // O teste buscarPorDia já foi atualizado implicitamente pela nova query buscarEventosParaData.
+}

--- a/app/src/androidTest/java/com/agendafocopei/data/GuiaDeAprendizagemDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/GuiaDeAprendizagemDaoTest.kt
@@ -1,0 +1,96 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import android.graphics.Color
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class GuiaDeAprendizagemDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var disciplinaDao: DisciplinaDao
+    private lateinit var guiaDeAprendizagemDao: GuiaDeAprendizagemDao
+
+    private var d1Id: Int = 0
+
+    @Before
+    fun createDb() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .fallbackToDestructiveMigration()
+            .build()
+        disciplinaDao = db.disciplinaDao()
+        guiaDeAprendizagemDao = db.guiaDeAprendizagemDao()
+
+        val disc1 = Disciplina(nome = "Português Guia", cor = Color.BLUE)
+        disciplinaDao.inserir(disc1)
+        d1Id = disciplinaDao.buscarPorNome("Português Guia")!!.id
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirGuia_eBuscarPorId_retornaGuiaCorreto() = runBlocking {
+        val guia = GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "1º Bimestre", ano = 2024, tituloGuia = "Guia Inicial", caminhoAnexoGuia = null, tipoAnexoGuia = null)
+        val id = guiaDeAprendizagemDao.inserir(guia)
+        val buscado = guiaDeAprendizagemDao.buscarPorId(id.toInt())
+        assertNotNull(buscado)
+        assertEquals("Guia Inicial", buscado?.tituloGuia)
+        assertEquals(d1Id, buscado?.disciplinaId)
+    }
+
+    @Test
+    fun buscarTodosParaDisplay_retornaGuiasComNomeDisciplina() = runBlocking {
+        guiaDeAprendizagemDao.inserir(GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "1º Bimestre", ano = 2024, tituloGuia = "Guia 1", null, null))
+        guiaDeAprendizagemDao.inserir(GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "2º Bimestre", ano = 2024, tituloGuia = "Guia 2", null, null))
+
+        val todosDisplay = guiaDeAprendizagemDao.buscarTodosParaDisplay().first()
+        assertEquals(2, todosDisplay.size)
+        assertEquals("Guia 2", todosDisplay[0].guiaDeAprendizagem.tituloGuia) // Ordenado por ano DESC, bimestre DESC
+        assertEquals("Português Guia", todosDisplay[0].nomeDisciplina)
+        assertEquals(Color.BLUE, todosDisplay[0].corDisciplina)
+    }
+
+    @Test
+    fun atualizarGuia_refleteMudancas() = runBlocking {
+        val guia = GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "3º Bimestre", ano = 2023, tituloGuia = "Antigo", null, null)
+        val id = guiaDeAprendizagemDao.inserir(guia)
+        val guiaParaAtualizar = guiaDeAprendizagemDao.buscarPorId(id.toInt())!!.copy(tituloGuia = "Novo Título")
+        guiaDeAprendizagemDao.atualizar(guiaParaAtualizar)
+        val buscado = guiaDeAprendizagemDao.buscarPorId(id.toInt())
+        assertEquals("Novo Título", buscado?.tituloGuia)
+    }
+
+    @Test
+    fun deletarGuia_naoDeveSerEncontrado() = runBlocking {
+        val guia = GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "4º Bimestre", ano = 2023, tituloGuia = "Para Deletar", null, null)
+        val id = guiaDeAprendizagemDao.inserir(guia)
+        val guiaParaDeletar = guiaDeAprendizagemDao.buscarPorId(id.toInt())!!
+        guiaDeAprendizagemDao.deletar(guiaParaDeletar)
+        assertNull(guiaDeAprendizagemDao.buscarPorId(id.toInt()))
+    }
+
+    @Test
+    fun onDeleteCascade_disciplinaDeletada_guiasSaoDeletados() = runBlocking {
+        val guia = GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "1º Bimestre", ano = 2025, tituloGuia = "Guia D1", null, null)
+        val idGuia = guiaDeAprendizagemDao.inserir(guia)
+        val disciplinaParaDeletar = disciplinaDao.buscarPorId(d1Id)!!
+        disciplinaDao.deletar(disciplinaParaDeletar)
+        assertNull(guiaDeAprendizagemDao.buscarPorId(idGuia.toInt()))
+    }
+}

--- a/app/src/androidTest/java/com/agendafocopei/data/ItemChecklistGuiaDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/ItemChecklistGuiaDaoTest.kt
@@ -1,0 +1,144 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class ItemChecklistGuiaDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var disciplinaDao: DisciplinaDao
+    private lateinit var guiaDeAprendizagemDao: GuiaDeAprendizagemDao
+    private lateinit var itemChecklistGuiaDao: ItemChecklistGuiaDao
+
+    private var d1Id: Int = 0
+    private var g1Id: Int = 0
+
+    @Before
+    fun createDb() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .fallbackToDestructiveMigration()
+            .build()
+        disciplinaDao = db.disciplinaDao()
+        guiaDeAprendizagemDao = db.guiaDeAprendizagemDao()
+        itemChecklistGuiaDao = db.itemChecklistGuiaDao()
+
+        val disc1 = Disciplina(nome = "Checklist Disc")
+        disciplinaDao.inserir(disc1)
+        d1Id = disciplinaDao.buscarPorNome("Checklist Disc")!!.id
+
+        val guia1 = GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "1º Check", ano = 2024)
+        g1Id = guiaDeAprendizagemDao.inserir(guia1).toInt()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirItemChecklist_eBuscarPorGuiaId_retornaItensCorretos() = runBlocking {
+        val item1 = ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item A", concluido = false)
+        val item2 = ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item B", concluido = true)
+        itemChecklistGuiaDao.inserir(item1)
+        itemChecklistGuiaDao.inserir(item2)
+
+        val itens = itemChecklistGuiaDao.buscarPorGuiaId(g1Id).first()
+        assertEquals(2, itens.size)
+        assertEquals("Item A", itens[0].descricaoItem)
+        assertFalse(itens[0].concluido)
+        assertEquals("Item B", itens[1].descricaoItem)
+        assertTrue(itens[1].concluido)
+    }
+
+    @Test
+    fun inserirVariosItens_eBuscarPorGuiaId_retornaTodos() = runBlocking {
+        val itensParaInserir = listOf(
+            ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item C", concluido = false),
+            ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item D", concluido = true)
+        )
+        itemChecklistGuiaDao.inserirVarios(itensParaInserir)
+        val itens = itemChecklistGuiaDao.buscarPorGuiaId(g1Id).first()
+        assertEquals(2, itens.size)
+    }
+
+
+    @Test
+    fun atualizarItemChecklist_concluidoMudou() = runBlocking {
+        val item = ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item E", concluido = false)
+        val id = itemChecklistGuiaDao.inserir(item).toInt()
+
+        val itemParaAtualizar = itemChecklistGuiaDao.buscarPorId(id)!!.copy(concluido = true)
+        itemChecklistGuiaDao.atualizar(itemParaAtualizar)
+
+        val atualizado = itemChecklistGuiaDao.buscarPorId(id)
+        assertTrue(atualizado!!.concluido)
+    }
+
+    @Test
+    fun atualizarVariosItens_refleteMudancas() = runBlocking {
+        val itemF = ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item F", concluido = false)
+        val itemG = ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item G", concluido = false)
+        val idF = itemChecklistGuiaDao.inserir(itemF).toInt()
+        val idG = itemChecklistGuiaDao.inserir(itemG).toInt()
+
+        val itensParaAtualizar = listOf(
+            itemChecklistGuiaDao.buscarPorId(idF)!!.copy(concluido = true),
+            itemChecklistGuiaDao.buscarPorId(idG)!!.copy(descricaoItem = "Item G Modificado")
+        )
+        itemChecklistGuiaDao.atualizarVarios(itensParaAtualizar)
+
+        assertTrue(itemChecklistGuiaDao.buscarPorId(idF)!!.concluido)
+        assertEquals("Item G Modificado", itemChecklistGuiaDao.buscarPorId(idG)!!.descricaoItem)
+    }
+
+
+    @Test
+    fun deletarItemChecklist_naoDeveSerEncontrado() = runBlocking {
+        val item = ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item H", concluido = false)
+        val id = itemChecklistGuiaDao.inserir(item).toInt()
+        val itemParaDeletar = itemChecklistGuiaDao.buscarPorId(id)!!
+        itemChecklistGuiaDao.deletar(itemParaDeletar)
+        assertNull(itemChecklistGuiaDao.buscarPorId(id))
+    }
+
+    @Test
+    fun deletarPorGuiaId_removeTodosOsItensDoGuia() = runBlocking {
+        itemChecklistGuiaDao.inserir(ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item I"))
+        itemChecklistGuiaDao.inserir(ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item J"))
+        // Adiciona item de outro guia para garantir que não seja deletado
+        val guia2 = GuiaDeAprendizagem(disciplinaId = d1Id, bimestre = "Outro", ano = 2024)
+        val g2Id = guiaDeAprendizagemDao.inserir(guia2).toInt()
+        itemChecklistGuiaDao.inserir(ItemChecklistGuia(guiaAprendizagemId = g2Id, descricaoItem = "Item K"))
+
+        itemChecklistGuiaDao.deletarPorGuiaId(g1Id)
+
+        assertTrue(itemChecklistGuiaDao.buscarPorGuiaId(g1Id).first().isEmpty())
+        assertFalse(itemChecklistGuiaDao.buscarPorGuiaId(g2Id).first().isEmpty())
+    }
+
+
+    @Test
+    fun onDeleteCascade_guiaDeletado_itensChecklistSaoDeletados() = runBlocking {
+        val item = ItemChecklistGuia(guiaAprendizagemId = g1Id, descricaoItem = "Item L", concluido = false)
+        val idItem = itemChecklistGuiaDao.inserir(item).toInt()
+
+        val guiaParaDeletar = guiaDeAprendizagemDao.buscarPorId(g1Id)!!
+        guiaDeAprendizagemDao.deletar(guiaParaDeletar) // CASCADE deve deletar o item
+
+        assertNull(itemChecklistGuiaDao.buscarPorId(idItem))
+    }
+}

--- a/app/src/androidTest/java/com/agendafocopei/data/MigrationTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/MigrationTest.kt
@@ -235,4 +235,305 @@ import java.util.Calendar // Import para Calendar
 
         dbV5.close()
     }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate5To6() {
+        // 1. Cria o banco de dados com o schema da versão 5.
+        // O helper aplicará MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4, e MIGRATION_4_5.
+        val dbV5 = helper.createDatabase(TEST_DB_NAME, 5).apply {
+            // Insere um evento na v5 (sem a coluna data_especifica)
+            val eventoValuesV5 = ContentValues().apply {
+                put("id", 1) // ID explícito para facilitar a consulta depois
+                put("nome_evento", "Evento V5 Teste")
+                put("dia_da_semana", Calendar.MONDAY)
+                put("hora_inicio", "10:00")
+                put("hora_fim", "11:00")
+                put("cor", Color.RED)
+            }
+            insert("eventos_recorrentes", SQLiteDatabase.CONFLICT_REPLACE, eventoValuesV5)
+            close()
+        }
+
+        // 2. Abre o banco de dados com a versão 6, aplicando SOMENTE a MIGRATION_5_6.
+        val dbV6 = helper.runMigrationsAndValidate(TEST_DB_NAME, 6, true, AppDatabase.MIGRATION_5_6)
+
+        // 3. Verifica se a coluna data_especifica foi adicionada e é NULL para dados antigos.
+        val cursor = dbV6.query("SELECT id, nome_evento, data_especifica, dia_da_semana FROM eventos_recorrentes WHERE id = 1")
+        assertTrue("Cursor do evento V5 está vazio.", cursor.moveToFirst())
+        assertEquals("Evento V5 Teste", cursor.getString(cursor.getColumnIndexOrThrow("nome_evento")))
+
+        val dataEspecificaColumnIndex = cursor.getColumnIndex("data_especifica")
+        assertTrue("Coluna 'data_especifica' não encontrada.", dataEspecificaColumnIndex >= 0)
+        assertTrue("Coluna 'data_especifica' não é NULL para dados antigos.", cursor.isNull(dataEspecificaColumnIndex))
+        assertEquals("Dia da semana deve ser mantido para evento recorrente antigo", Calendar.MONDAY, cursor.getInt(cursor.getColumnIndexOrThrow("dia_da_semana")))
+        cursor.close()
+
+        // 4. Opcional: Tenta inserir um novo Evento com data_especifica na v6.
+        val dataCal = Calendar.getInstance().apply { set(2024, Calendar.DECEMBER, 25) }
+        val dataStr = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(dataCal.time)
+
+        val eventoValuesV6 = ContentValues().apply {
+            put("nome_evento", "Natal V6")
+            put("dia_da_semana", dataCal.get(Calendar.DAY_OF_WEEK)) // Deve ser o dia da semana de dataEspecifica
+            put("hora_inicio", "00:00")
+            put("hora_fim", "23:59")
+            put("data_especifica", dataStr)
+            put("cor", Color.GREEN)
+        }
+        val insertResult = dbV6.insert("eventos_recorrentes", SQLiteDatabase.CONFLICT_REPLACE, eventoValuesV6)
+        assertTrue("Falha ao inserir evento V6 com data_especifica.", insertResult != -1L)
+
+        val newEventCursor = dbV6.query("SELECT data_especifica, dia_da_semana FROM eventos_recorrentes WHERE nome_evento = 'Natal V6'")
+        assertTrue("Novo evento V6 não encontrado.", newEventCursor.moveToFirst())
+        assertEquals(dataStr, newEventCursor.getString(newEventCursor.getColumnIndexOrThrow("data_especifica")))
+        assertEquals(dataCal.get(Calendar.DAY_OF_WEEK), newEventCursor.getInt(newEventCursor.getColumnIndexOrThrow("dia_da_semana")))
+        newEventCursor.close()
+
+        dbV6.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate6To7() {
+        // 1. Cria o banco de dados com o schema da versão 6.
+        // O helper aplicará todas as migrações de 1 até 6.
+        val dbV6 = helper.createDatabase(TEST_DB_NAME, 6).apply {
+            // Insere dados de teste relevantes para as tabelas existentes na versão 6,
+            // especialmente se as novas tabelas tiverem FKs para elas.
+            val disciplinaValues = ContentValues().apply {
+                put("id", 101); put("nome_disciplina", "Disc Mig6"); put("cor", Color.RED)
+            }
+            insert("disciplinas", SQLiteDatabase.CONFLICT_REPLACE, disciplinaValues)
+
+            val turmaValues = ContentValues().apply {
+                put("id", 201); put("nome_turma", "Turma Mig6"); put("cor", Color.BLUE)
+            }
+            insert("turmas", SQLiteDatabase.CONFLICT_REPLACE, turmaValues)
+
+            val horarioValues = ContentValues().apply {
+                put("id", 301)
+                put("dia_da_semana", Calendar.MONDAY)
+                put("hora_inicio", "07:00")
+                put("hora_fim", "07:45")
+                put("disciplinaId", 101)
+                put("turmaId", 201)
+            }
+            insert("horarios_aula", SQLiteDatabase.CONFLICT_REPLACE, horarioValues)
+            close()
+        }
+
+        // 2. Abre o banco de dados com a versão 7, aplicando SOMENTE a MIGRATION_6_7.
+        val dbV7 = helper.runMigrationsAndValidate(TEST_DB_NAME, 7, true, AppDatabase.MIGRATION_6_7)
+
+        // 3. Verifica se as novas tabelas foram criadas e estão vazias.
+        val tabelasParaVerificar = listOf(
+            "planos_de_aula",
+            "guias_de_aprendizagem",
+            "itens_checklist_guia",
+            "templates_plano_aula"
+        )
+        for (tabela in tabelasParaVerificar) {
+            val cursor = dbV7.query("SELECT * FROM $tabela")
+            assertNotNull("Cursor para $tabela não deve ser nulo.", cursor)
+            assertEquals("Tabela $tabela deve estar vazia após migração.", 0, cursor.count)
+            cursor.close()
+        }
+
+        // 4. Opcional: Tente inserir dados nas novas tabelas para verificar constraints e FKs.
+        // Exemplo para planos_de_aula (assumindo disciplinaId=101 e turmaId=201 existem):
+        val planoValues = ContentValues().apply {
+            put("disciplinaId", 101)
+            put("turmaId", 201)
+            put("horarioAulaId", 301)
+            put("titulo_plano", "Plano Teste Pós-Migração V7")
+            put("data_aula", "2024-09-01")
+        }
+        var insertResult = dbV7.insert("planos_de_aula", SQLiteDatabase.CONFLICT_REPLACE, planoValues)
+        assertTrue("Falha ao inserir em planos_de_aula pós-migração.", insertResult != -1L)
+
+        // Exemplo para guias_de_aprendizagem
+        val guiaValues = ContentValues().apply {
+            put("disciplinaId", 101)
+            put("bimestre", "3º Bimestre")
+            put("ano", 2024)
+            put("titulo_guia", "Guia Teste V7")
+        }
+        insertResult = dbV7.insert("guias_de_aprendizagem", SQLiteDatabase.CONFLICT_REPLACE, guiaValues)
+        assertTrue("Falha ao inserir em guias_de_aprendizagem pós-migração.", insertResult != -1L)
+        // Buscar o ID do guia inserido para usar no item do checklist
+        val guiaCursor = dbV7.query("SELECT id FROM guias_de_aprendizagem WHERE titulo_guia = 'Guia Teste V7'")
+        assertTrue(guiaCursor.moveToFirst())
+        val guiaIdInserido = guiaCursor.getInt(guiaCursor.getColumnIndexOrThrow("id"))
+        guiaCursor.close()
+
+        // Exemplo para itens_checklist_guia
+        val itemChecklistValues = ContentValues().apply {
+            put("guiaAprendizagemId", guiaIdInserido)
+            put("descricao_item", "Item de teste V7")
+            put("concluido", 0)
+        }
+        insertResult = dbV7.insert("itens_checklist_guia", SQLiteDatabase.CONFLICT_REPLACE, itemChecklistValues)
+        assertTrue("Falha ao inserir em itens_checklist_guia pós-migração.", insertResult != -1L)
+
+        // Exemplo para templates_plano_aula
+        val templateValues = ContentValues().apply {
+            put("nome_template", "Template Básico V7")
+        }
+        insertResult = dbV7.insert("templates_plano_aula", SQLiteDatabase.CONFLICT_REPLACE, templateValues)
+        assertTrue("Falha ao inserir em templates_plano_aula pós-migração.", insertResult != -1L)
+
+        dbV7.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate7To8() {
+        // 1. Cria o banco de dados com o schema da versão 7.
+        val dbV7 = helper.createDatabase(TEST_DB_NAME, 7).apply {
+            // Insere dados de teste relevantes para as tabelas existentes na versão 7,
+            // especialmente para FKs se a nova tabela 'tarefas' as usasse (disciplinaId, turmaId).
+            val disciplinaValues = ContentValues().apply {
+                put("id", 201); put("nome_disciplina", "Disc Mig7"); put("cor", Color.GREEN)
+            }
+            insert("disciplinas", SQLiteDatabase.CONFLICT_REPLACE, disciplinaValues)
+            val turmaValues = ContentValues().apply {
+                put("id", 301); put("nome_turma", "Turma Mig7"); put("cor", Color.YELLOW)
+            }
+            insert("turmas", SQLiteDatabase.CONFLICT_REPLACE, turmaValues)
+            close()
+        }
+
+        // 2. Abre o banco de dados com a versão 8, aplicando SOMENTE a MIGRATION_7_8.
+        val dbV8 = helper.runMigrationsAndValidate(TEST_DB_NAME, 8, true, AppDatabase.MIGRATION_7_8)
+
+        // 3. Verifica se a tabela 'tarefas' foi criada corretamente e está vazia.
+        val cursor = dbV8.query("SELECT * FROM tarefas")
+        assertNotNull("Cursor para tarefas não deve ser nulo.", cursor)
+        assertEquals("Tabela tarefas deve estar vazia após migração.", 0, cursor.count)
+        cursor.close()
+
+        // 4. Opcional: Tente inserir dados na nova tabela 'tarefas'.
+        val tarefaValues = ContentValues().apply {
+            put("descricao", "Tarefa Teste Pós-Migração V8")
+            put("prioridade", 1) // Média
+            put("disciplinaId", 201) // FK para a disciplina inserida na v7
+            put("turmaId", 301)     // FK para a turma inserida na v7
+            put("data_criacao", System.currentTimeMillis())
+            put("concluida", 0)
+            put("lembrete_configurado", 0)
+        }
+        val insertResult = dbV8.insert("tarefas", SQLiteDatabase.CONFLICT_REPLACE, tarefaValues)
+        assertTrue("Falha ao inserir em tarefas pós-migração.", insertResult != -1L)
+
+        val tarefaCursor = dbV8.query("SELECT * FROM tarefas WHERE descricao = 'Tarefa Teste Pós-Migração V8'")
+        assertTrue("Tarefa inserida não encontrada.", tarefaCursor.moveToFirst())
+        assertEquals(201, tarefaCursor.getInt(tarefaCursor.getColumnIndexOrThrow("disciplinaId")))
+        tarefaCursor.close()
+
+        dbV8.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate8To9() {
+        // 1. Cria o banco de dados com o schema da versão 8.
+        val dbV8 = helper.createDatabase(TEST_DB_NAME, 8).apply {
+            // Insere uma tarefa na v8 para ser pai da subtarefa.
+            val tarefaValuesV8 = ContentValues().apply {
+                put("id", 501) // ID explícito
+                put("descricao", "Tarefa Pai V8")
+                put("prioridade", 2)
+                put("data_criacao", System.currentTimeMillis())
+                put("concluida", 0)
+                put("lembrete_configurado", 0)
+            }
+            insert("tarefas", SQLiteDatabase.CONFLICT_REPLACE, tarefaValuesV8)
+            close()
+        }
+
+        // 2. Abre o banco de dados com a versão 9, aplicando SOMENTE a MIGRATION_8_9.
+        val dbV9 = helper.runMigrationsAndValidate(TEST_DB_NAME, 9, true, AppDatabase.MIGRATION_8_9)
+
+        // 3. Verifica se a tabela 'subtarefas' foi criada e está vazia.
+        val cursor = dbV9.query("SELECT * FROM subtarefas")
+        assertNotNull("Cursor para subtarefas não deve ser nulo.", cursor)
+        assertEquals("Tabela subtarefas deve estar vazia após migração.", 0, cursor.count)
+        cursor.close()
+
+        // 4. Opcional: Tente inserir dados na nova tabela 'subtarefas'.
+        val subtarefaValues = ContentValues().apply {
+            put("tarefaId", 501) // FK para a tarefa inserida na v8
+            put("descricao_subtarefa", "Subtarefa Teste Pós-Migração V9")
+            put("concluida", 0)
+            put("ordem", 0)
+        }
+        val insertResult = dbV9.insert("subtarefas", SQLiteDatabase.CONFLICT_REPLACE, subtarefaValues)
+        assertTrue("Falha ao inserir em subtarefas pós-migração.", insertResult != -1L)
+
+        val subtarefaCursor = dbV9.query("SELECT * FROM subtarefas WHERE tarefaId = 501")
+        assertTrue("Subtarefa inserida não encontrada.", subtarefaCursor.moveToFirst())
+        assertEquals("Subtarefa Teste Pós-Migração V9", subtarefaCursor.getString(subtarefaCursor.getColumnIndexOrThrow("descricao_subtarefa")))
+        subtarefaCursor.close()
+
+        // 5. Verifica se os dados da tabela 'tarefas' (da v8) ainda existem.
+        val tarefaPreservadaCursor = dbV9.query("SELECT * FROM tarefas WHERE id = 501")
+        assertTrue("Tarefa da v8 não foi preservada.", tarefaPreservadaCursor.moveToFirst())
+        assertEquals("Tarefa Pai V8", tarefaPreservadaCursor.getString(tarefaPreservadaCursor.getColumnIndexOrThrow("descricao")))
+        tarefaPreservadaCursor.close()
+
+        dbV9.close()
+    }
+
+    @Test
+    @Throws(IOException::class)
+    fun migrate9To10() {
+        // 1. Cria o banco de dados com o schema da versão 9.
+        // O helper aplicará todas as migrações de 1 até 9.
+        val dbV9 = helper.createDatabase(TEST_DB_NAME, 9).apply {
+            // Insere dados de teste relevantes para as tabelas existentes na versão 9,
+            // especialmente para FKs se a nova tabela 'anotacoes' as usasse (turmaId).
+            val turmaValues = ContentValues().apply {
+                put("id", 401); put("nome_turma", "Turma Mig9"); put("cor", Color.BLUE)
+            }
+            insert("turmas", SQLiteDatabase.CONFLICT_REPLACE, turmaValues)
+            // Poderia inserir uma Tarefa e Subtarefa também se quisesse ser exaustivo
+            // na verificação de preservação de todos os dados da v9.
+            close()
+        }
+
+        // 2. Abre o banco de dados com a versão 10, aplicando SOMENTE a MIGRATION_9_10.
+        val dbV10 = helper.runMigrationsAndValidate(TEST_DB_NAME, 10, true, AppDatabase.MIGRATION_9_10)
+
+        // 3. Verifica se a tabela 'anotacoes' foi criada corretamente e está vazia.
+        val cursor = dbV10.query("SELECT * FROM anotacoes")
+        assertNotNull("Cursor para anotacoes não deve ser nulo.", cursor)
+        assertEquals("Tabela anotacoes deve estar vazia após migração.", 0, cursor.count)
+        cursor.close()
+
+        // 4. Opcional: Tente inserir dados na nova tabela 'anotacoes'.
+        val anotacaoValues = ContentValues().apply {
+            put("conteudo", "Anotação Teste Pós-Migração V10")
+            put("data_criacao", System.currentTimeMillis())
+            put("data_modificacao", System.currentTimeMillis())
+            put("turmaId", 401) // FK para a turma inserida na v9
+            put("cor", Color.GREEN)
+        }
+        val insertResult = dbV10.insert("anotacoes", SQLiteDatabase.CONFLICT_REPLACE, anotacaoValues)
+        assertTrue("Falha ao inserir em anotacoes pós-migração.", insertResult != -1L)
+
+        val anotacaoCursor = dbV10.query("SELECT * FROM anotacoes WHERE conteudo = 'Anotação Teste Pós-Migração V10'")
+        assertTrue("Anotação inserida não encontrada.", anotacaoCursor.moveToFirst())
+        assertEquals(401, anotacaoCursor.getInt(anotacaoCursor.getColumnIndexOrThrow("turmaId")))
+        assertEquals(Color.GREEN, anotacaoCursor.getInt(anotacaoCursor.getColumnIndexOrThrow("cor")))
+        anotacaoCursor.close()
+
+        // 5. Verifica se os dados da tabela 'turmas' (da v9) ainda existem.
+        val turmaPreservadaCursor = dbV10.query("SELECT * FROM turmas WHERE id = 401")
+        assertTrue("Turma da v9 não foi preservada.", turmaPreservadaCursor.moveToFirst())
+        assertEquals("Turma Mig9", turmaPreservadaCursor.getString(turmaPreservadaCursor.getColumnIndexOrThrow("nome_turma")))
+        turmaPreservadaCursor.close()
+
+        dbV10.close()
+    }
 }

--- a/app/src/androidTest/java/com/agendafocopei/data/PlanoDeAulaDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/PlanoDeAulaDaoTest.kt
@@ -1,0 +1,169 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import android.graphics.Color
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.util.Calendar
+
+@RunWith(AndroidJUnit4::class)
+class PlanoDeAulaDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var disciplinaDao: DisciplinaDao
+    private lateinit var turmaDao: TurmaDao
+    private lateinit var horarioAulaDao: HorarioAulaDao
+    private lateinit var planoDeAulaDao: PlanoDeAulaDao
+
+    private var d1Id: Int = 0
+    private var t1Id: Int = 0
+    private var h1Id: Int = 0
+    private var d2Id: Int = 0 // Para testar FKs
+
+    @Before
+    fun createDb() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .fallbackToDestructiveMigration() // Para simplificar, se houver problemas com outras migrações não testadas aqui
+            .build()
+        disciplinaDao = db.disciplinaDao()
+        turmaDao = db.turmaDao()
+        horarioAulaDao = db.horarioAulaDao()
+        planoDeAulaDao = db.planoDeAulaDao()
+
+        val disc1 = Disciplina(nome = "História PDA", cor = Color.YELLOW)
+        val disc2 = Disciplina(nome = "Geografia PDA", cor = Color.CYAN)
+        disciplinaDao.inserir(disc1)
+        disciplinaDao.inserir(disc2)
+        d1Id = disciplinaDao.buscarPorNome("História PDA")!!.id
+        d2Id = disciplinaDao.buscarPorNome("Geografia PDA")!!.id
+
+
+        val turma1 = Turma(nome = "6A PDA", cor = Color.MAGENTA)
+        turmaDao.inserir(turma1)
+        t1Id = turmaDao.buscarPorNome("6A PDA")!!.id
+
+        val horario1 = HorarioAula(disciplinaId = d1Id, turmaId = t1Id, diaDaSemana = Calendar.MONDAY, horaInicio = "08:00", horaFim = "09:00", salaAula = "S1")
+        h1Id = horarioAulaDao.inserir(horario1).toInt()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirPlanoDeAula_eBuscarPorId_retornaPlanoCorreto() = runBlocking {
+        val plano = PlanoDeAula(horarioAulaId = h1Id, dataAula = "2024-08-01", disciplinaId = d1Id, turmaId = t1Id, tituloPlano = "Descobrimento", textoPlano = "Detalhes...", caminhoAnexo = null, tipoAnexo = null)
+        val id = planoDeAulaDao.inserir(plano)
+        val buscado = planoDeAulaDao.buscarPorId(id.toInt())
+        assertNotNull(buscado)
+        assertEquals("Descobrimento", buscado?.tituloPlano)
+        assertEquals(d1Id, buscado?.disciplinaId)
+    }
+
+    @Test
+    fun buscarPorHorarioAulaId_retornaPlanosCorretos() = runBlocking {
+        planoDeAulaDao.inserir(PlanoDeAula(horarioAulaId = h1Id, dataAula = "2024-08-01", disciplinaId = d1Id, turmaId = t1Id, tituloPlano = "Plano A", textoPlano = null, null, null))
+        planoDeAulaDao.inserir(PlanoDeAula(horarioAulaId = h1Id, dataAula = "2024-08-08", disciplinaId = d1Id, turmaId = t1Id, tituloPlano = "Plano B", textoPlano = null, null, null))
+        // Outro horário
+        val horario2 = HorarioAula(disciplinaId = d2Id, turmaId = t1Id, diaDaSemana = Calendar.TUESDAY, horaInicio = "10:00", horaFim = "11:00")
+        val h2Id = horarioAulaDao.inserir(horario2).toInt()
+        planoDeAulaDao.inserir(PlanoDeAula(horarioAulaId = h2Id, dataAula = "2024-08-02", disciplinaId = d2Id, turmaId = t1Id, tituloPlano = "Plano C", textoPlano = null, null, null))
+
+        val planosH1 = planoDeAulaDao.buscarPorHorarioAulaId(h1Id).first()
+        assertEquals(2, planosH1.size)
+        assertTrue(planosH1.all { it.horarioAulaId == h1Id })
+    }
+
+    @Test
+    fun buscarPorDisciplina_retornaPlanosCorretosEOrdenados() = runBlocking {
+        planoDeAulaDao.inserir(PlanoDeAula(disciplinaId = d1Id, dataAula = "2024-08-10", horarioAulaId = null, turmaId = null, tituloPlano = "Tardio D1", textoPlano = null, null, null))
+        planoDeAulaDao.inserir(PlanoDeAula(disciplinaId = d1Id, dataAula = "2024-08-01", horarioAulaId = null, turmaId = null, tituloPlano = "Cedo D1", textoPlano = null, null, null))
+        planoDeAulaDao.inserir(PlanoDeAula(disciplinaId = d2Id, dataAula = "2024-08-05", horarioAulaId = null, turmaId = null, tituloPlano = "Unico D2", textoPlano = null, null, null))
+
+        val planosD1 = planoDeAulaDao.buscarPorDisciplina(d1Id).first()
+        assertEquals(2, planosD1.size)
+        assertEquals("Tardio D1", planosD1[0].tituloPlano) // Ordenado por data DESC
+        assertEquals("Cedo D1", planosD1[1].tituloPlano)
+    }
+
+    @Test
+    fun buscarTodosParaDisplay_retornaDadosCompletosEOrdenados() = runBlocking {
+        planoDeAulaDao.inserir(PlanoDeAula(disciplinaId = d1Id, turmaId = t1Id, dataAula = "2024-08-10", tituloPlano = "Plano D1T1", horarioAulaId = null, textoPlano = null, null, null))
+        planoDeAulaDao.inserir(PlanoDeAula(disciplinaId = d2Id, turmaId = null, dataAula = "2024-08-01", tituloPlano = "Plano D2 Geral", horarioAulaId = null, textoPlano = null, null, null))
+
+        val todosDisplay = planoDeAulaDao.buscarTodosParaDisplay().first()
+        assertEquals(2, todosDisplay.size)
+        assertEquals("Plano D1T1", todosDisplay[0].planoDeAula.tituloPlano)
+        assertEquals("História PDA", todosDisplay[0].nomeDisciplina)
+        assertEquals("6A PDA", todosDisplay[0].nomeTurma)
+        assertEquals(Color.YELLOW, todosDisplay[0].corDisciplina)
+
+        assertEquals("Plano D2 Geral", todosDisplay[1].planoDeAula.tituloPlano)
+        assertEquals("Geografia PDA", todosDisplay[1].nomeDisciplina)
+        assertNull(todosDisplay[1].nomeTurma) // Turma é opcional (LEFT JOIN)
+    }
+
+
+    @Test
+    fun atualizarPlanoDeAula_refleteMudancas() = runBlocking {
+        val plano = PlanoDeAula(disciplinaId = d1Id, tituloPlano = "Original", horarioAulaId = null, turmaId = null, dataAula = null, textoPlano = null, null, null)
+        val id = planoDeAulaDao.inserir(plano)
+        val planoParaAtualizar = planoDeAulaDao.buscarPorId(id.toInt())!!.copy(tituloPlano = "Atualizado")
+        planoDeAulaDao.atualizar(planoParaAtualizar)
+        val buscado = planoDeAulaDao.buscarPorId(id.toInt())
+        assertEquals("Atualizado", buscado?.tituloPlano)
+    }
+
+    @Test
+    fun deletarPlanoDeAula_naoDeveSerEncontrado() = runBlocking {
+        val plano = PlanoDeAula(disciplinaId = d1Id, tituloPlano = "Para Deletar", horarioAulaId = null, turmaId = null, dataAula = null, textoPlano = null, null, null)
+        val id = planoDeAulaDao.inserir(plano)
+        val planoParaDeletar = planoDeAulaDao.buscarPorId(id.toInt())!!
+        planoDeAulaDao.deletar(planoParaDeletar)
+        assertNull(planoDeAulaDao.buscarPorId(id.toInt()))
+    }
+
+    @Test
+    fun onDeleteCascade_disciplinaDeletada_planosSaoDeletados() = runBlocking {
+        val plano = PlanoDeAula(disciplinaId = d1Id, tituloPlano = "Plano D1", horarioAulaId = null, turmaId = null, dataAula = null, textoPlano = null, null, null)
+        val idPlano = planoDeAulaDao.inserir(plano)
+        val disciplinaParaDeletar = disciplinaDao.buscarPorId(d1Id)!!
+        disciplinaDao.deletar(disciplinaParaDeletar)
+        assertNull(planoDeAulaDao.buscarPorId(idPlano.toInt()))
+    }
+
+    @Test
+    fun onDeleteSetNull_horarioAulaDeletado_planoHorarioAulaIdEhNull() = runBlocking {
+        val plano = PlanoDeAula(horarioAulaId = h1Id, disciplinaId = d1Id, tituloPlano = "Plano H1", turmaId = null, dataAula = null, textoPlano = null, null, null)
+        val idPlano = planoDeAulaDao.inserir(plano)
+        val horarioParaDeletar = horarioAulaDao.buscarPorId(h1Id)!!
+        horarioAulaDao.deletar(horarioParaDeletar) // onDelete = SET_NULL para horarioAulaId
+        val planoRecuperado = planoDeAulaDao.buscarPorId(idPlano.toInt())
+        assertNotNull(planoRecuperado)
+        assertNull(planoRecuperado?.horarioAulaId)
+    }
+
+    @Test
+    fun onDeleteSetNull_turmaDeletada_planoTurmaIdEhNull() = runBlocking {
+        val plano = PlanoDeAula(turmaId = t1Id, disciplinaId = d1Id, tituloPlano = "Plano T1", horarioAulaId = null, dataAula = null, textoPlano = null, null, null)
+        val idPlano = planoDeAulaDao.inserir(plano)
+        val turmaParaDeletar = turmaDao.buscarPorId(t1Id)!!
+        turmaDao.deletar(turmaParaDeletar) // onDelete = SET_NULL para turmaId
+        val planoRecuperado = planoDeAulaDao.buscarPorId(idPlano.toInt())
+        assertNotNull(planoRecuperado)
+        assertNull(planoRecuperado?.turmaId)
+    }
+}

--- a/app/src/androidTest/java/com/agendafocopei/data/SubtarefaDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/SubtarefaDaoTest.kt
@@ -1,0 +1,120 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class SubtarefaDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var tarefaDao: TarefaDao
+    private lateinit var subtarefaDao: SubtarefaDao
+
+    private var tarefaPaiId: Int = 0
+
+    @Before
+    fun createDb() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .fallbackToDestructiveMigration()
+            .build()
+        tarefaDao = db.tarefaDao()
+        subtarefaDao = db.subtarefaDao()
+
+        val tarefaPai = Tarefa(descricao = "Tarefa Pai para Subtarefas", prioridade = 1)
+        tarefaPaiId = tarefaDao.inserir(tarefaPai).toInt()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirSubtarefa_eBuscarPorTarefaId_retornaSubtarefasCorretasEOrdenadas() = runBlocking {
+        val sub1 = Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub A", ordem = 1)
+        val sub2 = Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub B", ordem = 0)
+        subtarefaDao.inserir(sub1)
+        subtarefaDao.inserir(sub2)
+
+        val subtarefas = subtarefaDao.buscarPorTarefaId(tarefaPaiId).first()
+        assertEquals(2, subtarefas.size)
+        assertEquals("Sub B", subtarefas[0].descricaoSubtarefa) // Ordem 0 primeiro
+        assertEquals("Sub A", subtarefas[1].descricaoSubtarefa)
+    }
+
+    @Test
+    fun atualizarSubtarefa_refleteMudancas() = runBlocking {
+        val sub = Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Original Sub", concluida = false)
+        val id = subtarefaDao.inserir(sub).toInt()
+
+        val paraAtualizar = subtarefaDao.buscarPorId(id)!!.copy(descricaoSubtarefa = "Atualizada Sub", concluida = true)
+        subtarefaDao.atualizar(paraAtualizar)
+
+        val atualizada = subtarefaDao.buscarPorId(id)!!
+        assertEquals("Atualizada Sub", atualizada.descricaoSubtarefa)
+        assertTrue(atualizada.concluida)
+    }
+
+    @Test
+    fun deletarSubtarefa_naoDeveSerEncontrada() = runBlocking {
+        val sub = Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub para Deletar")
+        val id = subtarefaDao.inserir(sub).toInt()
+        val paraDeletar = subtarefaDao.buscarPorId(id)!!
+        subtarefaDao.deletar(paraDeletar)
+        assertNull(subtarefaDao.buscarPorId(id))
+    }
+
+    @Test
+    fun deleteById_subtarefaNaoDeveSerEncontrada() = runBlocking {
+        val sub = Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub para Deletar por ID")
+        val id = subtarefaDao.inserir(sub).toInt()
+        subtarefaDao.deleteById(id)
+        assertNull(subtarefaDao.buscarPorId(id))
+    }
+
+
+    @Test
+    fun deleteTodasPorTarefaId_removeApenasSubtarefasDaTarefaCorreta() = runBlocking {
+        // Tarefa 2 para isolamento
+        val tarefaPai2 = Tarefa(descricao = "Tarefa Pai 2", prioridade = 0)
+        val tarefaPai2Id = tarefaDao.inserir(tarefaPai2).toInt()
+
+        subtarefaDao.inserir(Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub 1 T1"))
+        subtarefaDao.inserir(Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub 2 T1"))
+        subtarefaDao.inserir(Subtarefa(tarefaId = tarefaPai2Id, descricaoSubtarefa = "Sub 1 T2"))
+
+        subtarefaDao.deleteTodasPorTarefaId(tarefaPaiId)
+
+        assertTrue(subtarefaDao.buscarPorTarefaId(tarefaPaiId).first().isEmpty())
+        assertFalse(subtarefaDao.buscarPorTarefaId(tarefaPai2Id).first().isEmpty())
+        assertEquals(1, subtarefaDao.buscarPorTarefaId(tarefaPai2Id).first().size)
+    }
+
+    @Test
+    fun onDeleteCascade_tarefaDeletada_subtarefasSaoDeletadas() = runBlocking {
+        val sub1 = Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub X")
+        val sub2 = Subtarefa(tarefaId = tarefaPaiId, descricaoSubtarefa = "Sub Y")
+        val idSub1 = subtarefaDao.inserir(sub1).toInt()
+        val idSub2 = subtarefaDao.inserir(sub2).toInt()
+
+        val tarefaParaDeletar = tarefaDao.buscarPorId(tarefaPaiId)!!
+        tarefaDao.deletar(tarefaParaDeletar) // CASCADE deve deletar sub1 e sub2
+
+        assertNull(subtarefaDao.buscarPorId(idSub1))
+        assertNull(subtarefaDao.buscarPorId(idSub2))
+        assertTrue(subtarefaDao.buscarPorTarefaId(tarefaPaiId).first().isEmpty())
+    }
+}

--- a/app/src/androidTest/java/com/agendafocopei/data/TarefaDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/TarefaDaoTest.kt
@@ -1,0 +1,212 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import android.graphics.Color
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+import java.text.SimpleDateFormat
+import java.util.*
+
+@RunWith(AndroidJUnit4::class)
+class TarefaDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var tarefaDao: TarefaDao
+    private lateinit var disciplinaDao: DisciplinaDao
+    private lateinit var turmaDao: TurmaDao
+
+    private var d1Id: Int = 0
+    private var t1Id: Int = 0
+    private val queryDateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+
+    @Before
+    fun createDb() = runBlocking {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .fallbackToDestructiveMigration()
+            .build()
+        tarefaDao = db.tarefaDao()
+        disciplinaDao = db.disciplinaDao()
+        turmaDao = db.turmaDao()
+
+        val disc1 = Disciplina(nome = "Tarefa Disc", cor = Color.GREEN)
+        disciplinaDao.inserir(disc1)
+        d1Id = disciplinaDao.buscarPorNome("Tarefa Disc")!!.id
+
+        val turma1 = Turma(nome = "Tarefa Turma", cor = Color.BLUE)
+        turmaDao.inserir(turma1)
+        t1Id = turmaDao.buscarPorNome("Tarefa Turma")!!.id
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirTarefa_eBuscarPorId_retornaTarefaCorreta() = runBlocking {
+        val prazoCal = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 5); set(Calendar.HOUR_OF_DAY, 10); set(Calendar.MINUTE, 30) }
+        val lembreteTime = prazoCal.timeInMillis - (60 * 60 * 1000) // 1 hora antes
+        val tarefa = Tarefa(
+            descricao = "Tarefa Teste 1",
+            prazoData = queryDateFormat.format(prazoCal.time),
+            prazoHora = "10:30",
+            prioridade = 2, // Alta
+            disciplinaId = d1Id,
+            turmaId = t1Id,
+            concluida = false,
+            lembreteConfigurado = true,
+            lembreteDateTime = lembreteTime
+        )
+        val id = tarefaDao.inserir(tarefa)
+        val buscada = tarefaDao.buscarPorId(id.toInt())
+        assertNotNull(buscada)
+        assertEquals("Tarefa Teste 1", buscada?.descricao)
+        assertEquals(queryDateFormat.format(prazoCal.time), buscada?.prazoData)
+        assertEquals("10:30", buscada?.prazoHora)
+        assertEquals(2, buscada?.prioridade)
+        assertEquals(d1Id, buscada?.disciplinaId)
+        assertEquals(t1Id, buscada?.turmaId)
+        assertFalse(buscada!!.concluida)
+        assertTrue(buscada.lembreteConfigurado)
+        assertEquals(lembreteTime, buscada.lembreteDateTime)
+    }
+
+    @Test
+    fun buscarPendentesOrdenadas_retornaApenasPendentesEOrdenadas() = runBlocking {
+        val hojeCal = Calendar.getInstance()
+        val amanhaCal = Calendar.getInstance().apply{ add(Calendar.DAY_OF_YEAR, 1)}
+
+        tarefaDao.inserir(Tarefa(descricao = "Pendente Alta Prio Hoje", prazoData = queryDateFormat.format(hojeCal.time), prazoHora = "10:00", prioridade = 2, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "Pendente Media Prio Amanha", prazoData = queryDateFormat.format(amanhaCal.time), prazoHora = "11:00", prioridade = 1, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "Pendente Baixa Prio Hoje", prazoData = queryDateFormat.format(hojeCal.time), prazoHora = "12:00", prioridade = 0, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "Concluída", prazoData = null, prazoHora = null, prioridade = 2, concluida = true, disciplinaId = null, turmaId = null))
+
+        val pendentes = tarefaDao.buscarPendentesOrdenadas().first()
+        assertEquals(3, pendentes.size)
+        assertEquals("Pendente Alta Prio Hoje", pendentes[0].descricao) // Alta prioridade primeiro
+        assertEquals("Pendente Media Prio Amanha", pendentes[1].descricao) // Depois por prazo (Amanha > Hoje, mas prioridade manda)
+        assertEquals("Pendente Baixa Prio Hoje", pendentes[2].descricao) // Baixa prioridade por último
+    }
+
+    @Test
+    fun buscarConcluidasOrdenadas_retornaApenasConcluidasEOrdenadas() = runBlocking {
+        val t1 = Tarefa(descricao = "Concluida Antes", concluida = true, dataConclusao = System.currentTimeMillis() - 10000, prioridade = 0, disciplinaId = null, turmaId = null)
+        val t2 = Tarefa(descricao = "Concluida Agora", concluida = true, dataConclusao = System.currentTimeMillis(), prioridade = 0, disciplinaId = null, turmaId = null)
+        tarefaDao.inserir(t1)
+        tarefaDao.inserir(t2)
+        tarefaDao.inserir(Tarefa(descricao = "Pendente", concluida = false, prioridade = 0, disciplinaId = null, turmaId = null))
+
+        val concluidas = tarefaDao.buscarConcluidasOrdenadas().first()
+        assertEquals(2, concluidas.size)
+        assertEquals("Concluida Agora", concluidas[0].descricao) // Mais recente primeiro
+        assertEquals("Concluida Antes", concluidas[1].descricao)
+    }
+
+
+    @Test
+    fun buscarTarefasUrgentes_retornaTarefasCorretas() = runBlocking {
+        val formatoQuery = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+        val hojeCal = Calendar.getInstance()
+        val amanhaCal = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 1) }
+        val depoisAmanhaCal = Calendar.getInstance().apply { add(Calendar.DAY_OF_YEAR, 2) }
+
+        val hojeStr = formatoQuery.format(hojeCal.time)
+        val amanhaStr = formatoQuery.format(amanhaCal.time)
+        val depoisAmanhaStr = formatoQuery.format(depoisAmanhaCal.time)
+
+        // Urgentes
+        tarefaDao.inserir(Tarefa(descricao = "Urgente Hoje 10h Prio Alta", prazoData = hojeStr, prazoHora = "10:00", prioridade = 2, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "Urgente Amanha 09h Prio Media", prazoData = amanhaStr, prazoHora = "09:00", prioridade = 1, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "Urgente Hoje 08h Prio Media", prazoData = hojeStr, prazoHora = "08:00", prioridade = 1, disciplinaId = null, turmaId = null))
+        // Não urgentes
+        tarefaDao.inserir(Tarefa(descricao = "Concluída Urgente", prazoData = hojeStr, prazoHora = "11:00", prioridade = 2, concluida = true, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "Depois de Amanhã", prazoData = depoisAmanhaStr, prazoHora = "10:00", prioridade = 2, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "Sem Prazo", prazoData = null, prazoHora = null, prioridade = 2, disciplinaId = null, turmaId = null))
+
+
+        val urgentes = tarefaDao.buscarTarefasUrgentes(hojeStr, amanhaStr).first()
+        assertEquals(3, urgentes.size)
+        assertEquals("Urgente Hoje 08h Prio Media", urgentes[0].descricao) // Ordenado por data, hora, prioridade
+        assertEquals("Urgente Hoje 10h Prio Alta", urgentes[1].descricao)
+        assertEquals("Urgente Amanha 09h Prio Media", urgentes[2].descricao)
+    }
+
+    @Test
+    fun buscarPorDataDePrazo_retornaTarefasCorretas() = runBlocking {
+        val dataAlvo = "2024-10-20"
+        val outraData = "2024-10-21"
+        tarefaDao.inserir(Tarefa(descricao = "T1 Data Alvo 10h", prazoData = dataAlvo, prazoHora = "10:00", prioridade = 1, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "T2 Data Alvo 08h", prazoData = dataAlvo, prazoHora = "08:00", prioridade = 2, disciplinaId = null, turmaId = null))
+        tarefaDao.inserir(Tarefa(descricao = "T3 Outra Data", prazoData = outraData, prazoHora = "09:00", prioridade = 1, disciplinaId = null, turmaId = null))
+
+        val porData = tarefaDao.buscarPorDataDePrazo(dataAlvo).first()
+        assertEquals(2, porData.size)
+        assertEquals("T2 Data Alvo 08h", porData[0].descricao) // Ordenado por hora, prioridade
+        assertEquals("T1 Data Alvo 10h", porData[1].descricao)
+    }
+
+    @Test
+    fun atualizarTarefa_refleteMudancas() = runBlocking {
+        val tarefa = Tarefa(descricao = "Original", prioridade = 0, concluida = false, disciplinaId = null, turmaId = null)
+        val id = tarefaDao.inserir(tarefa).toInt()
+        val paraAtualizar = tarefaDao.buscarPorId(id)!!.copy(descricao = "Atualizada", concluida = true, prioridade = 2)
+        tarefaDao.atualizar(paraAtualizar)
+        val atualizada = tarefaDao.buscarPorId(id)!!
+        assertEquals("Atualizada", atualizada.descricao)
+        assertTrue(atualizada.concluida)
+        assertEquals(2, atualizada.prioridade)
+    }
+
+    @Test
+    fun deletarTarefa_naoDeveSerEncontrada() = runBlocking {
+        val tarefa = Tarefa(descricao = "Para Deletar", prioridade = 0, disciplinaId = null, turmaId = null)
+        val id = tarefaDao.inserir(tarefa).toInt()
+        val paraDeletar = tarefaDao.buscarPorId(id)!!
+        tarefaDao.deletar(paraDeletar)
+        assertNull(tarefaDao.buscarPorId(id))
+    }
+
+    @Test
+    fun deleteById_tarefaNaoDeveSerEncontrada() = runBlocking {
+        val tarefa = Tarefa(descricao = "Para Deletar por ID", prioridade = 0, disciplinaId = null, turmaId = null)
+        val id = tarefaDao.inserir(tarefa).toInt()
+        tarefaDao.deleteById(id)
+        assertNull(tarefaDao.buscarPorId(id))
+    }
+
+
+    @Test
+    fun onDeleteSetNull_disciplinaDeletada_tarefaDisciplinaIdEhNull() = runBlocking {
+        val tarefa = Tarefa(descricao = "Com Disc", disciplinaId = d1Id, prioridade = 0, turmaId = null)
+        val id = tarefaDao.inserir(tarefa).toInt()
+        val disciplina = disciplinaDao.buscarPorId(d1Id)!!
+        disciplinaDao.deletar(disciplina) // onDelete = SET_NULL
+        val tarefaAtualizada = tarefaDao.buscarPorId(id)
+        assertNotNull(tarefaAtualizada)
+        assertNull(tarefaAtualizada?.disciplinaId)
+    }
+
+    @Test
+    fun onDeleteSetNull_turmaDeletada_tarefaTurmaIdEhNull() = runBlocking {
+        val tarefa = Tarefa(descricao = "Com Turma", turmaId = t1Id, prioridade = 0, disciplinaId = null)
+        val id = tarefaDao.inserir(tarefa).toInt()
+        val turma = turmaDao.buscarPorId(t1Id)!!
+        turmaDao.deletar(turma) // onDelete = SET_NULL
+        val tarefaAtualizada = tarefaDao.buscarPorId(id)
+        assertNotNull(tarefaAtualizada)
+        assertNull(tarefaAtualizada?.turmaId)
+    }
+}

--- a/app/src/androidTest/java/com/agendafocopei/data/TemplatePlanoAulaDaoTest.kt
+++ b/app/src/androidTest/java/com/agendafocopei/data/TemplatePlanoAulaDaoTest.kt
@@ -1,0 +1,79 @@
+package com.agendafocopei.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.IOException
+
+@RunWith(AndroidJUnit4::class)
+class TemplatePlanoAulaDaoTest {
+
+    private lateinit var db: AppDatabase
+    private lateinit var templatePlanoAulaDao: TemplatePlanoAulaDao
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, AppDatabase::class.java)
+            .allowMainThreadQueries()
+            .fallbackToDestructiveMigration()
+            .build()
+        templatePlanoAulaDao = db.templatePlanoAulaDao()
+    }
+
+    @After
+    @Throws(IOException::class)
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun inserirTemplate_eBuscarPorId_retornaTemplateCorreto() = runBlocking {
+        val template = TemplatePlanoAula(nomeTemplate = "Padrão Expositivo", campoHabilidades = "H1, H2", campoRecursos = "Livro, Lousa", campoMetodologia = "Aula expositiva", campoAvaliacao = "Prova", outrosCampos = null)
+        val id = templatePlanoAulaDao.inserir(template)
+        val buscado = templatePlanoAulaDao.buscarPorId(id.toInt())
+        assertNotNull(buscado)
+        assertEquals("Padrão Expositivo", buscado?.nomeTemplate)
+        assertEquals("H1, H2", buscado?.campoHabilidades)
+    }
+
+    @Test
+    fun buscarTodos_retornaListaOrdenadaPorNome() = runBlocking {
+        templatePlanoAulaDao.inserir(TemplatePlanoAula(nomeTemplate = "Template C", null,null,null,null,null))
+        templatePlanoAulaDao.inserir(TemplatePlanoAula(nomeTemplate = "Template A", null,null,null,null,null))
+        templatePlanoAulaDao.inserir(TemplatePlanoAula(nomeTemplate = "Template B", null,null,null,null,null))
+
+        val todos = templatePlanoAulaDao.buscarTodos().first()
+        assertEquals(3, todos.size)
+        assertEquals("Template A", todos[0].nomeTemplate)
+        assertEquals("Template B", todos[1].nomeTemplate)
+        assertEquals("Template C", todos[2].nomeTemplate)
+    }
+
+    @Test
+    fun atualizarTemplate_refleteMudancas() = runBlocking {
+        val template = TemplatePlanoAula(nomeTemplate = "Original", campoMetodologia = "Antiga", null,null,null,null)
+        val id = templatePlanoAulaDao.inserir(template)
+        val paraAtualizar = templatePlanoAulaDao.buscarPorId(id.toInt())!!.copy(campoMetodologia = "Nova Metodologia")
+        templatePlanoAulaDao.atualizar(paraAtualizar)
+        val buscado = templatePlanoAulaDao.buscarPorId(id.toInt())
+        assertEquals("Nova Metodologia", buscado?.campoMetodologia)
+    }
+
+    @Test
+    fun deletarTemplate_naoDeveSerEncontrado() = runBlocking {
+        val template = TemplatePlanoAula(nomeTemplate = "Para Deletar", null,null,null,null,null)
+        val id = templatePlanoAulaDao.inserir(template)
+        val paraDeletar = templatePlanoAulaDao.buscarPorId(id.toInt())!!
+        templatePlanoAulaDao.deletar(paraDeletar)
+        assertNull(templatePlanoAulaDao.buscarPorId(id.toInt()))
+    }
+}

--- a/app/src/main/java/com/agendafocopei/MainActivity.kt
+++ b/app/src/main/java/com/agendafocopei/MainActivity.kt
@@ -1,0 +1,131 @@
+package com.agendafocopei
+
+import android.content.Intent
+import android.graphics.Color
+import android.os.Bundle
+import android.util.Log
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.Disciplina
+import com.agendafocopei.data.DisciplinaDao
+import com.agendafocopei.databinding.ActivityMainBinding
+import com.agendafocopei.ui.activity.* // Import para as activities de UI
+import com.agendafocopei.ui.dialog.ColorPickerDialogFragment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class MainActivity : AppCompatActivity(), ColorPickerDialogFragment.ColorPickerListener {
+
+    private lateinit var binding: ActivityMainBinding
+    private lateinit var disciplinaAdapter: DisciplinaAdapter
+    private lateinit var disciplinaDao: DisciplinaDao
+    private var corSelecionadaDisciplina: Int? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        disciplinaDao = AppDatabase.getDatabase(applicationContext).disciplinaDao()
+
+        disciplinaAdapter = DisciplinaAdapter(emptyList())
+        binding.recyclerViewDisciplinas.layoutManager = LinearLayoutManager(this)
+        binding.recyclerViewDisciplinas.adapter = disciplinaAdapter
+
+        lifecycleScope.launch {
+            disciplinaDao.buscarTodas().collect { disciplinasDaBase ->
+                disciplinaAdapter.updateDisciplinas(disciplinasDaBase)
+            }
+        }
+
+        binding.buttonAdicionarDisciplina.setOnClickListener {
+            val nomeDisciplina = binding.editTextDisciplina.text.toString().trim()
+            if (nomeDisciplina.isNotEmpty()) {
+                lifecycleScope.launch {
+                    val disciplinaExistente = withContext(Dispatchers.IO) {
+                        disciplinaDao.buscarPorNome(nomeDisciplina)
+                    }
+                    if (disciplinaExistente == null) {
+                        val novaDisciplina = Disciplina(nome = nomeDisciplina, cor = corSelecionadaDisciplina)
+                        withContext(Dispatchers.IO) {
+                            disciplinaDao.inserir(novaDisciplina)
+                        }
+                        binding.editTextDisciplina.text?.clear()
+                        binding.editTextDisciplina.error = null
+                        corSelecionadaDisciplina = null
+                        binding.viewPreviewCorSelecionadaDisciplina.setBackgroundColor(Color.TRANSPARENT)
+                    } else {
+                        binding.editTextDisciplina.error = "Disciplina já existe"
+                    }
+                }
+            } else {
+                binding.editTextDisciplina.error = "Nome não pode ser vazio"
+            }
+        }
+
+        binding.buttonEscolherCorDisciplina.setOnClickListener {
+            val dialog = ColorPickerDialogFragment.newInstance(
+                preselectedColor = corSelecionadaDisciplina,
+                requestTag = "disciplina_color"
+            )
+            dialog.show(supportFragmentManager, ColorPickerDialogFragment.TAG)
+        }
+
+        binding.buttonGerenciarTurmas.setOnClickListener {
+            val intent = Intent(this, CadastroTurmaActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.buttonGerenciarHorarios.setOnClickListener {
+            val intent = Intent(this, GerenciarHorarioActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.buttonGerenciarEventos.setOnClickListener {
+            val intent = Intent(this, GerenciarEventosActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.buttonVerDashboard.setOnClickListener {
+            val intent = Intent(this, DashboardActivity::class.java)
+            startActivity(intent)
+        }
+
+        // Novo botão para Planos de Aula
+        binding.buttonGerenciarPlanosDeAula.setOnClickListener {
+            val intent = Intent(this, PlanosDeAulaGeralActivity::class.java)
+            startActivity(intent)
+        }
+
+        // Novo botão para Guias de Aprendizagem
+        binding.buttonGerenciarGuias.setOnClickListener {
+            val intent = Intent(this, GuiasDeAprendizagemActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.buttonGerenciarTemplatesPlanoAula.setOnClickListener { // Supondo ID buttonGerenciarTemplatesPlanoAula
+            val intent = Intent(this, TemplatesPlanoAulaActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.buttonGerenciarTarefas.setOnClickListener { // Supondo ID buttonGerenciarTarefas
+            val intent = Intent(this, TarefasActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.buttonMinhasAnotacoes.setOnClickListener { // Supondo ID buttonMinhasAnotacoes
+            val intent = Intent(this, AnotacoesActivity::class.java)
+            startActivity(intent)
+        }
+    }
+
+    override fun onColorSelected(color: Int, tag: String?) {
+        if (tag == "disciplina_color") {
+            corSelecionadaDisciplina = color
+            binding.viewPreviewCorSelecionadaDisciplina.setBackgroundColor(color)
+        }
+    }
+}

--- a/app/src/main/java/com/agendafocopei/ui/activity/AnotacoesActivity.kt
+++ b/app/src/main/java/com/agendafocopei/ui/activity/AnotacoesActivity.kt
@@ -1,0 +1,126 @@
+package com.agendafocopei.ui.activity
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.Anotacao
+import com.agendafocopei.data.AnotacaoDao
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.TurmaDao
+import com.agendafocopei.databinding.ActivityAnotacoesBinding
+import com.agendafocopei.ui.adapter.AnotacaoAdapter
+import com.agendafocopei.ui.dialog.FormularioAnotacaoFragment // Import do DialogFragment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class AnotacoesActivity : AppCompatActivity(), FormularioAnotacaoFragment.FormularioAnotacaoListener {
+
+    private lateinit var binding: ActivityAnotacoesBinding
+    private lateinit var anotacaoAdapter: AnotacaoAdapter
+    private lateinit var anotacaoDao: AnotacaoDao
+    private lateinit var turmaDao: TurmaDao
+
+    companion object {
+        const val EXTRA_ABRIR_FORMULARIO_NOVA_ANOTACAO = "abrir_formulario_nova_anotacao"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityAnotacoesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val db = AppDatabase.getDatabase(applicationContext)
+        anotacaoDao = db.anotacaoDao()
+        turmaDao = db.turmaDao()
+
+        setSupportActionBar(binding.toolbarAnotacoes)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupRecyclerView()
+        observeAnotacoes()
+
+        binding.fabAdicionarAnotacao.setOnClickListener {
+            abrirFormularioAnotacao(null)
+        }
+
+        if (intent.getBooleanExtra(EXTRA_ABRIR_FORMULARIO_NOVA_ANOTACAO, false)) {
+            intent.removeExtra(EXTRA_ABRIR_FORMULARIO_NOVA_ANOTACAO)
+            abrirFormularioAnotacao(null)
+        }
+    }
+
+    private fun setupRecyclerView() {
+        anotacaoAdapter = AnotacaoAdapter(
+            turmaDao = turmaDao,
+            onItemClickListener = { anotacao ->
+                abrirFormularioAnotacao(anotacao.id)
+            },
+            onEditClickListener = { anotacao ->
+                abrirFormularioAnotacao(anotacao.id)
+            },
+            onDeleteClickListener = { anotacao ->
+                mostrarDialogoConfirmacaoDelete(anotacao)
+            }
+        )
+        binding.recyclerViewAnotacoes.apply {
+            adapter = anotacaoAdapter
+            layoutManager = LinearLayoutManager(this@AnotacoesActivity)
+        }
+    }
+
+    private fun observeAnotacoes() {
+        lifecycleScope.launch {
+            anotacaoDao.buscarTodas().collect { listaAnotacoes ->
+                anotacaoAdapter.submitList(listaAnotacoes)
+                binding.textViewListaVaziaAnotacoes.visibility = if (listaAnotacoes.isEmpty()) View.VISIBLE else View.GONE
+                binding.recyclerViewAnotacoes.visibility = if (listaAnotacoes.isEmpty()) View.GONE else View.VISIBLE
+            }
+        }
+    }
+
+    private fun abrirFormularioAnotacao(anotacaoId: Int?) {
+        val formularioDialog = FormularioAnotacaoFragment.newInstance(anotacaoId)
+        formularioDialog.setListener(this)
+        formularioDialog.show(supportFragmentManager, FormularioAnotacaoFragment.TAG)
+    }
+
+    // Implementação do FormularioAnotacaoListener
+    override fun onAnotacaoSalva(anotacao: Anotacao) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            anotacaoDao.inserir(anotacao) // OnConflict REPLACE
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@AnotacoesActivity, "Anotação salva!", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    private fun mostrarDialogoConfirmacaoDelete(anotacao: Anotacao) {
+        AlertDialog.Builder(this)
+            .setTitle("Confirmar Exclusão")
+            .setMessage("Tem certeza que deseja excluir esta anotação?")
+            .setPositiveButton("Excluir") { _, _ ->
+                deletarAnotacao(anotacao)
+            }
+            .setNegativeButton("Cancelar", null)
+            .show()
+    }
+
+    private fun deletarAnotacao(anotacao: Anotacao) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            anotacaoDao.deletar(anotacao)
+            withContext(Dispatchers.Main) {
+                Toast.makeText(this@AnotacoesActivity, "Anotação excluída.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/app/src/main/java/com/agendafocopei/ui/activity/DashboardActivity.kt
+++ b/app/src/main/java/com/agendafocopei/ui/activity/DashboardActivity.kt
@@ -10,15 +10,20 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.agendafocopei.R
 import com.agendafocopei.data.AppDatabase
-import com.agendafocopei.data.Evento // ATUALIZADO
-import com.agendafocopei.data.EventoDao // ATUALIZADO
+import com.agendafocopei.data.Evento
+import com.agendafocopei.data.EventoDao
 import com.agendafocopei.data.HorarioAulaDao
+import com.agendafocopei.data.TarefaDao
 import com.agendafocopei.databinding.ActivityDashboardBinding
 import com.agendafocopei.ui.adapter.AgendaHojeAdapter
+import com.agendafocopei.ui.adapter.TarefaAdapter
+import com.agendafocopei.ui.bottomsheet.DetalhesEventoSheetFragment
 import com.agendafocopei.ui.model.HorarioAulaDisplay
 import com.agendafocopei.ui.model.ItemAgendaDashboard
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -26,62 +31,93 @@ class DashboardActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityDashboardBinding
     private lateinit var horarioAulaDao: HorarioAulaDao
-    private lateinit var eventoDao: EventoDao // ATUALIZADO
+    private lateinit var eventoDao: EventoDao
+    private lateinit var tarefaDao: TarefaDao
     private lateinit var agendaHojeAdapter: AgendaHojeAdapter
+    private lateinit var tarefaUrgenteAdapter: TarefaAdapter
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding = ActivityDashboardBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // Inicialização dos DAOs
         val database = AppDatabase.getDatabase(applicationContext)
         horarioAulaDao = database.horarioAulaDao()
-        eventoDao = database.eventoDao() // ATUALIZADO
+        eventoDao = database.eventoDao()
+        tarefaDao = database.tarefaDao()
 
-        // Configurar a Toolbar
         setSupportActionBar(binding.toolbarDashboard)
         supportActionBar?.setDisplayHomeAsUpEnabled(true)
 
-        // Formatar e exibir a data atual
         val calendario = Calendar.getInstance()
-        val formatoData = SimpleDateFormat("EEEE, d 'de' MMMM", Locale("pt", "BR"))
-        var dataFormatada = formatoData.format(calendario.time)
+        val formatoDataDisplay = SimpleDateFormat("EEEE, d 'de' MMMM", Locale("pt", "BR"))
+        var dataFormatada = formatoDataDisplay.format(calendario.time)
         dataFormatada = dataFormatada.split(" ").joinToString(" ") { palavra ->
             palavra.replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale("pt", "BR")) else it.toString() }
         }
         binding.textViewDataAtualDashboard.text = "Hoje, ${dataFormatada.substringAfter(", ")}"
 
-        // Configurar RecyclerViews
-        binding.recyclerViewTarefasUrgentesDashboard.layoutManager = LinearLayoutManager(this)
-        // binding.recyclerViewTarefasUrgentesDashboard.adapter = null // Adapter de tarefas virá depois
+        setupRecyclerViews()
 
-        agendaHojeAdapter = AgendaHojeAdapter()
-        binding.recyclerViewAgendaHojeDashboard.layoutManager = LinearLayoutManager(this)
-        binding.recyclerViewAgendaHojeDashboard.adapter = agendaHojeAdapter
-
-        // Configurar OnClickListeners para botões de Ações Rápidas
         binding.buttonNovaTarefaDashboard.setOnClickListener {
-            Toast.makeText(this, "Funcionalidade 'Nova Tarefa' em breve!", Toast.LENGTH_SHORT).show()
+            val intent = Intent(this, TarefasActivity::class.java)
+            intent.putExtra(TarefasActivity.EXTRA_ABRIR_FORMULARIO_NOVA_TAREFA, true)
+            startActivity(intent)
         }
         binding.buttonAnotacaoRapidaDashboard.setOnClickListener {
-            Toast.makeText(this, "Funcionalidade 'Anotação Rápida' em breve!", Toast.LENGTH_SHORT).show()
+            // Atualizado para abrir AnotacoesActivity com o extra
+            val intent = Intent(this, AnotacoesActivity::class.java)
+            intent.putExtra(AnotacoesActivity.EXTRA_ABRIR_FORMULARIO_NOVA_ANOTACAO, true)
+            startActivity(intent)
         }
         binding.buttonFocoDashboard.setOnClickListener {
-            Toast.makeText(this, "Funcionalidade 'Foco (Pomodoro)' em breve!", Toast.LENGTH_SHORT).show()
+            val intent = Intent(this, PomodoroActivity::class.java)
+            startActivity(intent)
         }
 
-        // Botão para ver Agenda Completa
         binding.buttonVerAgendaCompleta.setOnClickListener {
             val intent = Intent(this, AgendaActivity::class.java)
             startActivity(intent)
         }
     }
 
+    private fun setupRecyclerViews() {
+        tarefaUrgenteAdapter = TarefaAdapter(
+            onTarefaCheckChanged = { tarefaDisplay, isChecked ->
+                lifecycleScope.launch(Dispatchers.IO) {
+                    val tarefaAtualizada = tarefaDisplay.tarefa.copy(
+                        concluida = isChecked,
+                        dataConclusao = if (isChecked) System.currentTimeMillis() else null
+                    )
+                    tarefaDao.atualizar(tarefaAtualizada)
+                }
+            },
+            onEditClickListener = { tarefaDisplay ->
+                val intent = Intent(this, TarefasActivity::class.java)
+                Toast.makeText(this, "Editar Tarefa ID: ${tarefaDisplay.tarefa.id} (abrirá lista de tarefas)", Toast.LENGTH_SHORT).show()
+                startActivity(intent)
+            }
+        )
+        binding.recyclerViewTarefasUrgentesDashboard.layoutManager = LinearLayoutManager(this)
+        binding.recyclerViewTarefasUrgentesDashboard.adapter = tarefaUrgenteAdapter
+
+        agendaHojeAdapter = AgendaHojeAdapter { item ->
+            val (id, type) = when (item) {
+                is ItemAgendaDashboard.AulaItem -> Pair(item.aula.id, "aula")
+                is ItemAgendaDashboard.EventoItem -> Pair(item.evento.id, "evento")
+            }
+            DetalhesEventoSheetFragment.newInstance(id, type)
+                .show(supportFragmentManager, DetalhesEventoSheetFragment.TAG)
+        }
+        binding.recyclerViewAgendaHojeDashboard.layoutManager = LinearLayoutManager(this)
+        binding.recyclerViewAgendaHojeDashboard.adapter = agendaHojeAdapter
+    }
+
     override fun onResume() {
         super.onResume()
         carregarProximoCompromisso()
         carregarAgendaDoDia()
+        carregarTarefasUrgentes()
     }
 
     private fun carregarProximoCompromisso() {
@@ -90,31 +126,28 @@ class DashboardActivity : AppCompatActivity() {
             val diaSemanaAtual = calendar.get(Calendar.DAY_OF_WEEK)
             val formatoHora = SimpleDateFormat("HH:mm", Locale.getDefault())
             val horaAtualStr = formatoHora.format(calendar.time)
-            val dataAtualStr = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.time) // Data para nova query
+            val dataAtualStr = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.time)
 
             val proximaAula = horarioAulaDao.buscarProximoHorarioAulaDoDia(diaSemanaAtual, horaAtualStr)
-            val proximoEvento = eventoDao.buscarProximoEventoParaData(diaSemanaAtual, dataAtualStr, horaAtualStr) // Query atualizada
-
+            val proximoEvento = eventoDao.buscarProximoEventoParaData(diaSemanaAtual, dataAtualStr, horaAtualStr)
             atualizarUIProximoCompromisso(proximaAula, proximoEvento)
         }
     }
 
-    private fun atualizarUIProximoCompromisso(proximaAula: HorarioAulaDisplay?, proximoEvento: Evento?) { // Tipo atualizado
+    private fun atualizarUIProximoCompromisso(proximaAula: HorarioAulaDisplay?, proximoEvento: Evento?) {
         val cardProximoCompromisso = binding.cardViewProximoCompromisso
-
         val nenhumCompromisso = proximaAula == null && proximoEvento == null
-        binding.textViewNenhumCompromissoHoje.visibility = if (nenhumCompromisso) View.VISIBLE else View.GONE
 
+        binding.textViewNenhumCompromissoHoje.visibility = if (nenhumCompromisso) View.VISIBLE else View.GONE
         binding.textViewHorarioProximoCompromisso.visibility = if (nenhumCompromisso) View.GONE else View.VISIBLE
         binding.textViewNomeProximoCompromisso.visibility = if (nenhumCompromisso) View.GONE else View.VISIBLE
         binding.textViewSalaLocalProximoCompromisso.visibility = if (nenhumCompromisso) View.GONE else View.VISIBLE
-        binding.textViewTurmaProximoCompromisso.visibility = View.GONE // Resetar antes de decidir
+        binding.textViewTurmaProximoCompromisso.visibility = View.GONE
 
         if (nenhumCompromisso) {
             cardProximoCompromisso.setCardBackgroundColor(Color.TRANSPARENT)
             return
         }
-
         var compromissoNome: String
         var compromissoHorario: String
         var compromissoSalaLocal: String?
@@ -139,10 +172,7 @@ class DashboardActivity : AppCompatActivity() {
             compromissoHorario = "${proximoEvento.horaInicio} - ${proximoEvento.horaFim}"
             compromissoSalaLocal = proximoEvento.salaLocal
             compromissoCor = proximoEvento.cor
-        } else {
-            // Should not happen if !nenhumCompromisso
-            return
-        }
+        } else { return }
 
         binding.textViewNomeProximoCompromisso.text = compromissoNome
         binding.textViewHorarioProximoCompromisso.text = compromissoHorario
@@ -153,12 +183,10 @@ class DashboardActivity : AppCompatActivity() {
             binding.textViewSalaLocalProximoCompromisso.visibility = View.VISIBLE
             binding.textViewSalaLocalProximoCompromisso.text = compromissoSalaLocal
         }
-
         if (nomeTurma != null) {
             binding.textViewTurmaProximoCompromisso.text = nomeTurma
             binding.textViewTurmaProximoCompromisso.visibility = View.VISIBLE
         }
-
         cardProximoCompromisso.setCardBackgroundColor(compromissoCor ?: Color.parseColor("#E0E0E0"))
     }
 
@@ -166,13 +194,13 @@ class DashboardActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val calendar = Calendar.getInstance()
             val diaSemanaAtual = calendar.get(Calendar.DAY_OF_WEEK)
-            val dataAtualStr = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.time) // Data para nova query
+            val dataAtualStr = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).format(calendar.time)
 
             horarioAulaDao.buscarTodosParaDisplayPorDia(diaSemanaAtual)
-                .combine(eventoDao.buscarEventosParaData(diaSemanaAtual, dataAtualStr)) { aulasDoDia, eventosDoDia -> // Query atualizada
+                .combine(eventoDao.buscarEventosParaData(diaSemanaAtual, dataAtualStr)) { aulasDoDia, eventosDoDia ->
                     val itensCombinados = mutableListOf<ItemAgendaDashboard>()
                     aulasDoDia.forEach { itensCombinados.add(ItemAgendaDashboard.AulaItem(it)) }
-                    eventosDoDia.forEach { itensCombinados.add(ItemAgendaDashboard.EventoItem(it)) } // EventoItem agora recebe Evento
+                    eventosDoDia.forEach { itensCombinados.add(ItemAgendaDashboard.EventoItem(it)) }
                     itensCombinados.sortBy { item -> item.horaInicio }
                     itensCombinados
                 }.collect { itensAgrupadosEOrdenados ->
@@ -180,6 +208,28 @@ class DashboardActivity : AppCompatActivity() {
                     binding.textViewPlaceholderAgenda.visibility = if (itensAgrupadosEOrdenados.isEmpty()) View.VISIBLE else View.GONE
                     binding.recyclerViewAgendaHojeDashboard.visibility = if (itensAgrupadosEOrdenados.isEmpty()) View.GONE else View.VISIBLE
                 }
+        }
+    }
+
+    private fun carregarTarefasUrgentes() {
+        lifecycleScope.launch {
+            val calendar = Calendar.getInstance()
+            val formatoQuery = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+            val hojeStr = formatoQuery.format(calendar.time)
+            calendar.add(Calendar.DAY_OF_YEAR, 1)
+            val amanhaStr = formatoQuery.format(calendar.time)
+
+            tarefaDao.buscarUrgentesParaDisplay(hojeStr, amanhaStr).collect { listaTarefasUrgentes ->
+                tarefaUrgenteAdapter.submitList(listaTarefasUrgentes)
+                if (listaTarefasUrgentes.isEmpty()) {
+                    binding.textViewPlaceholderTarefas.text = "Nenhuma tarefa urgente para hoje ou amanhã."
+                    binding.textViewPlaceholderTarefas.visibility = View.VISIBLE
+                    binding.recyclerViewTarefasUrgentesDashboard.visibility = View.GONE
+                } else {
+                    binding.textViewPlaceholderTarefas.visibility = View.GONE
+                    binding.recyclerViewTarefasUrgentesDashboard.visibility = View.VISIBLE
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/agendafocopei/ui/activity/PomodoroActivity.kt
+++ b/app/src/main/java/com/agendafocopei/ui/activity/PomodoroActivity.kt
@@ -1,0 +1,231 @@
+package com.agendafocopei.ui.activity
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.provider.Settings
+import android.view.View
+import android.widget.Toast
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.NotificationManagerCompat // Import para compatibilidade
+import androidx.lifecycle.Observer
+import com.agendafocopei.R // Necessário para R.drawable
+import com.agendafocopei.databinding.ActivityPomodoroBinding
+import com.agendafocopei.ui.pomodoro.ConfigPomodoroDialogFragment
+import com.agendafocopei.ui.pomodoro.PomodoroState
+import com.agendafocopei.ui.pomodoro.PomodoroViewModel
+import java.util.concurrent.TimeUnit
+
+class PomodoroActivity : AppCompatActivity(), ConfigPomodoroDialogFragment.ConfigPomodoroListener {
+
+    private lateinit var binding: ActivityPomodoroBinding
+    private val viewModel: PomodoroViewModel by viewModels()
+    private lateinit var notificationManager: NotificationManager // Para DND
+    private lateinit var notificationManagerCompat: NotificationManagerCompat // Para notificações
+
+    private val POMODORO_CHANNEL_ID = "POMODORO_CHANNEL_ID"
+
+
+    private val requestDndPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.StartActivityForResult()
+    ) { _ ->
+        if (notificationManager.isNotificationPolicyAccessGranted) {
+            Toast.makeText(this, "Permissão Não Perturbe concedida!", Toast.LENGTH_SHORT).show()
+            if (viewModel.estadoAtual.value == PomodoroState.PRONTO && viewModel.ativarModoHiperfoco.value == true) {
+                 viewModel.iniciarPausar(applicationContext)
+            }
+        } else {
+            Toast.makeText(this, "Permissão Não Perturbe não concedida. Modo Hiperfoco pode não funcionar como esperado.", Toast.LENGTH_LONG).show()
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityPomodoroBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        notificationManagerCompat = NotificationManagerCompat.from(this)
+
+
+        createNotificationChannel() // Criar canal de notificação
+
+        val prefs = getSharedPreferences(PomodoroViewModel.PREFS_NAME, Context.MODE_PRIVATE)
+        viewModel.inicializarComPrefs(applicationContext, prefs)
+
+        setSupportActionBar(binding.toolbarPomodoro)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupObservers()
+        setupClickListeners()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val name = "Temporizador Pomodoro" // Nome visível para o usuário
+            val descriptionText = "Notificações persistentes para o temporizador Pomodoro"
+            val importance = NotificationManager.IMPORTANCE_LOW // Para não fazer som/vibrar a cada update
+            val channel = NotificationChannel(POMODORO_CHANNEL_ID, name, importance).apply {
+                description = descriptionText
+                setSound(null, null) // Som da notificação será tocado manualmente pelo ViewModel/MediaPlayer
+            }
+            // Registrar o canal com o sistema
+            val manager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+            manager.createNotificationChannel(channel)
+        }
+    }
+
+
+    private fun setupObservers() {
+        viewModel.tempoRestanteMillis.observe(this, Observer { millis ->
+            val minutos = TimeUnit.MILLISECONDS.toMinutes(millis)
+            val segundos = TimeUnit.MILLISECONDS.toSeconds(millis) % 60
+            val tempoFormatado = String.format("%02d:%02d", minutos, segundos)
+            binding.textViewTempoPomodoro.text = tempoFormatado
+
+            val totalMillis = viewModel.tempoTotalCicloAtualMillis.value ?: millis
+            if (totalMillis > 0) {
+                val progresso = ((totalMillis - millis).toFloat() / totalMillis * 100).toInt()
+                binding.progressBarPomodoro.progress = progresso
+            } else {
+                binding.progressBarPomodoro.progress = 0
+            }
+            // Atualizar notificação com o tempo
+            if (viewModel.isTimerEffectivelyRunning()) { // Só atualiza se estiver rodando
+                 viewModel.mostrarOuAtualizarNotificacao(applicationContext, tempoFormatado)
+            }
+        })
+
+        viewModel.estadoAtual.observe(this, Observer { estado ->
+            val tempoFormatadoAtual = binding.textViewTempoPomodoro.text.toString() // Pega o tempo já formatado
+            when (estado) {
+                PomodoroState.PRONTO -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Pronto"
+                    binding.buttonIniciarPausarPomodoro.text = "Iniciar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = false
+                    binding.buttonPularCicloPomodoro.isEnabled = false
+                    binding.progressBarPomodoro.progress = 0
+                    viewModel.cancelarNotificacao(applicationContext)
+                }
+                PomodoroState.FOCO -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Foco"
+                    binding.buttonIniciarPausarPomodoro.text = "Pausar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                    viewModel.mostrarOuAtualizarNotificacao(applicationContext, tempoFormatadoAtual)
+                }
+                PomodoroState.PAUSA_CURTA -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Pausa Curta"
+                    binding.buttonIniciarPausarPomodoro.text = "Pausar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                    viewModel.mostrarOuAtualizarNotificacao(applicationContext, tempoFormatadoAtual)
+                }
+                PomodoroState.PAUSA_LONGA -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Pausa Longa"
+                    binding.buttonIniciarPausarPomodoro.text = "Pausar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                    viewModel.mostrarOuAtualizarNotificacao(applicationContext, tempoFormatadoAtual)
+                }
+                PomodoroState.PAUSADO -> {
+                    binding.textViewEstadoCicloPomodoro.text = "Pausado"
+                    binding.buttonIniciarPausarPomodoro.text = "Retomar"
+                    binding.buttonIniciarPausarPomodoro.isEnabled = true
+                    binding.buttonResetarPomodoro.isEnabled = true
+                    binding.buttonPularCicloPomodoro.isEnabled = true
+                    // Atualiza notificação para refletir estado pausado, mas com tempo atual
+                    viewModel.mostrarOuAtualizarNotificacao(applicationContext, tempoFormatadoAtual)
+                }
+                null -> {}
+            }
+        })
+
+        viewModel.cicloFocoAtual.observe(this, Observer { ciclo ->
+            val totalCiclosParaPausaLonga = viewModel.ciclosAtePausaLonga.value ?: 4
+            if (ciclo > 0 && viewModel.estadoAtual.value != PomodoroState.PRONTO) {
+                binding.textViewNumeroCicloPomodoro.text = "Ciclo: $ciclo/$totalCiclosParaPausaLonga"
+                binding.textViewNumeroCicloPomodoro.visibility = View.VISIBLE
+            } else {
+                 binding.textViewNumeroCicloPomodoro.text = "Ciclo: -/-"
+            }
+        })
+
+        viewModel.ativarModoHiperfoco.observe(this) { hiperfocoAtivado ->
+            if (hiperfocoAtivado && (viewModel.estadoAtual.value == PomodoroState.PRONTO || viewModel.estadoAtual.value == PomodoroState.FOCO)) {
+                verificarESolicitarPermissaoDnd()
+            }
+        }
+    }
+
+    private fun setupClickListeners() {
+        binding.buttonIniciarPausarPomodoro.setOnClickListener {
+            if (viewModel.estadoAtual.value == PomodoroState.PRONTO && viewModel.ativarModoHiperfoco.value == true) {
+                if (!notificationManager.isNotificationPolicyAccessGranted) {
+                    verificarESolicitarPermissaoDnd()
+                } else {
+                    viewModel.iniciarPausar(applicationContext)
+                }
+            } else {
+                viewModel.iniciarPausar(applicationContext)
+            }
+        }
+        binding.buttonResetarPomodoro.setOnClickListener {
+            viewModel.resetarCicloAtualOuPomodoro(applicationContext)
+        }
+        binding.buttonPularCicloPomodoro.setOnClickListener {
+            viewModel.pularParaProximoCiclo(applicationContext)
+        }
+        binding.buttonConfigPomodoro.setOnClickListener {
+            ConfigPomodoroDialogFragment.newInstance().show(supportFragmentManager, ConfigPomodoroDialogFragment.TAG)
+        }
+    }
+
+    private fun verificarESolicitarPermissaoDnd() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !notificationManager.isNotificationPolicyAccessGranted) {
+            AlertDialog.Builder(this)
+                .setTitle("Permissão Necessária")
+                .setMessage("Para o Modo Hiperfoco funcionar, o app precisa de permissão para gerenciar o Modo Não Perturbe. Deseja ir para as configurações conceder?")
+                .setPositiveButton("Sim") { _, _ ->
+                    val intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+                    requestDndPermissionLauncher.launch(intent)
+                }
+                .setNegativeButton("Não", null)
+                .show()
+        }
+    }
+
+    override fun onConfigSalva(focoMin: Int, curtaMin: Int, longaMin: Int, ciclos: Int, hiperfoco: Boolean, som: Boolean) {
+        viewModel.setConfiguracoes(focoMin, curtaMin, longaMin, ciclos, hiperfoco, som)
+        Toast.makeText(this, "Configurações salvas e aplicadas.", Toast.LENGTH_SHORT).show()
+        if (hiperfoco) {
+            verificarESolicitarPermissaoDnd()
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        // Se o timer não for para rodar em background (ViewModel sobrevive à Activity)
+        // e a activity está realmente sendo destruída (não por mudança de config),
+        // pode ser um local para cancelar a notificação se o ViewModel não for limpo.
+        // Mas o onCleared do ViewModel é geralmente mais seguro.
+        // if (isFinishing) {
+        //     viewModel.cancelarNotificacao(applicationContext)
+        // }
+    }
+}

--- a/app/src/main/java/com/agendafocopei/ui/activity/TarefasActivity.kt
+++ b/app/src/main/java/com/agendafocopei/ui/activity/TarefasActivity.kt
@@ -1,0 +1,174 @@
+package com.agendafocopei.ui.activity
+
+import android.os.Bundle
+import android.view.View
+import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.Subtarefa // Import Subtarefa
+import com.agendafocopei.data.SubtarefaDao // Import SubtarefaDao
+import com.agendafocopei.data.Tarefa
+import com.agendafocopei.data.TarefaDao
+import com.agendafocopei.databinding.ActivityTarefasBinding
+import com.agendafocopei.ui.adapter.TarefaAdapter
+import android.util.Log // Import para Log
+import com.agendafocopei.ui.dialog.FormularioTarefaFragment
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.SimpleDateFormat // Para formatar data do lembrete
+import java.util.Date // Para formatar data do lembrete
+import java.util.Locale // Para formatar data do lembrete
+
+class TarefasActivity : AppCompatActivity(), FormularioTarefaFragment.FormularioTarefaListener {
+
+    private lateinit var binding: ActivityTarefasBinding
+    private lateinit var tarefaAdapter: TarefaAdapter
+    private lateinit var tarefaDao: TarefaDao
+    private lateinit var subtarefaDao: SubtarefaDao // Adicionado SubtarefaDao
+
+    companion object {
+        const val EXTRA_ABRIR_FORMULARIO_NOVA_TAREFA = "abrir_formulario_nova_tarefa"
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityTarefasBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val db = AppDatabase.getDatabase(applicationContext)
+        tarefaDao = db.tarefaDao()
+        subtarefaDao = db.subtarefaDao() // Inicializar SubtarefaDao
+
+        setSupportActionBar(binding.toolbarTarefas)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupRecyclerView()
+        observeTarefasPendentes()
+
+        binding.fabAdicionarTarefa.setOnClickListener {
+            abrirFormularioTarefa(null)
+        }
+
+        if (intent.getBooleanExtra(EXTRA_ABRIR_FORMULARIO_NOVA_TAREFA, false)) {
+            intent.removeExtra(EXTRA_ABRIR_FORMULARIO_NOVA_TAREFA)
+            abrirFormularioTarefa(null)
+        }
+    }
+
+    private fun setupRecyclerView() {
+        tarefaAdapter = TarefaAdapter(
+            onTarefaCheckChanged = { tarefaDisplay, isChecked ->
+                lifecycleScope.launch(Dispatchers.IO) {
+                    val tarefaAtualizada = tarefaDisplay.tarefa.copy(
+                        concluida = isChecked,
+                        dataConclusao = if (isChecked) System.currentTimeMillis() else null
+                    )
+                    tarefaDao.atualizar(tarefaAtualizada)
+                }
+            },
+            onEditClickListener = { tarefaDisplay ->
+                abrirFormularioTarefa(tarefaDisplay.tarefa.id)
+            }
+        )
+        binding.recyclerViewTarefas.apply {
+            adapter = tarefaAdapter
+            layoutManager = LinearLayoutManager(this@TarefasActivity)
+        }
+    }
+
+    private fun observeTarefasPendentes() {
+        lifecycleScope.launch {
+            tarefaDao.buscarPendentesParaDisplay().collect { listaTarefas ->
+                tarefaAdapter.submitList(listaTarefas)
+                binding.textViewListaVaziaTarefas.visibility = if (listaTarefas.isEmpty()) View.VISIBLE else View.GONE
+                binding.recyclerViewTarefas.visibility = if (listaTarefas.isEmpty()) View.GONE else View.VISIBLE
+            }
+        }
+    }
+
+    private fun abrirFormularioTarefa(tarefaId: Int?) {
+        val formularioDialog = FormularioTarefaFragment.newInstance(tarefaId)
+        formularioDialog.setListener(this)
+        formularioDialog.show(supportFragmentManager, FormularioTarefaFragment.TAG)
+    }
+
+    // Implementação do FormularioTarefaListener atualizada
+    override fun onTarefaSalva(tarefa: Tarefa, subtarefas: List<Subtarefa>) {
+        lifecycleScope.launch(Dispatchers.IO) {
+            val tarefaIdSalva: Int
+            if (tarefa.id == 0) { // Nova tarefa
+                tarefaIdSalva = tarefaDao.inserir(tarefa).toInt()
+            } else { // Tarefa existente (atualização)
+                tarefaDao.atualizar(tarefa)
+                tarefaIdSalva = tarefa.id
+                // Deleta subtarefas antigas antes de reinserir as atualizadas
+                subtarefaDao.deleteTodasPorTarefaId(tarefaIdSalva)
+            }
+
+            // Insere as subtarefas (novas ou atualizadas) com o ID correto da tarefa pai
+            subtarefas.forEach { subtarefa ->
+                // Se a subtarefa da lista já tem um ID (veio do banco), ela será atualizada pelo REPLACE.
+                // Se for nova (id=0), será inserida.
+                // A abordagem deleteTodasPorTarefaId + inserir todas simplifica, mas pode ser ineficiente para muitas subtarefas.
+                // Uma abordagem mais otimizada rastrearia IDs para update/delete/insert individual.
+                // Para esta implementação, vamos manter a simplicidade: deletar todas e reinserir.
+                // No entanto, ao reinserir, queremos que o Room gere novos IDs para as subtarefas se elas não tinham um,
+                // ou atualize se elas tinham. A estratégia de `subtarefa.copy(tarefaId = tarefaIdSalva, id = 0)`
+                // força a criação de novas subtarefas sempre, o que pode não ser o ideal se quisermos manter os IDs das subtarefas.
+                // Vamos assumir que a lista de subtarefas do fragmento já tem os IDs corretos se forem edições de subtarefas existentes,
+                // ou id=0 se forem novas subtarefas adicionadas na UI.
+                subtarefaDao.inserir(subtarefa.copy(tarefaId = tarefaIdSalva))
+            }
+
+            // Lógica do Lembrete (Placeholder)
+            // Usar o objeto 'tarefa' que foi passado para onTarefaSalva,
+            // pois ele contém os dados do formulário (lembreteConfigurado, lembreteDateTime).
+            // O ID correto para Log/Toast é tarefaIdSalva.
+            val tarefaParaLembrete = tarefa.copy(id = tarefaIdSalva)
+
+
+            if (tarefaParaLembrete.lembreteConfigurado && tarefaParaLembrete.lembreteDateTime != null) {
+                if (tarefaParaLembrete.lembreteDateTime!! > System.currentTimeMillis()) {
+                    val dataFormatada = SimpleDateFormat("dd/MM/yyyy HH:mm", Locale.getDefault())
+                        .format(Date(tarefaParaLembrete.lembreteDateTime!!))
+
+                    Log.d("TarefasActivity_Lembrete", "Lembrete AGENDADO para Tarefa ID: ${tarefaParaLembrete.id} ('${tarefaParaLembrete.descricao}') em $dataFormatada")
+                    // É importante mostrar o Toast na UI Thread
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(this@TarefasActivity, "Lembrete para '${tarefaParaLembrete.descricao}' configurado para $dataFormatada.", Toast.LENGTH_LONG).show()
+                    }
+                    // IMPLEMENTAÇÃO REAL (futuro) com AlarmManager...
+                } else {
+                    Log.w("TarefasActivity_Lembrete", "Lembrete para Tarefa ID: ${tarefaParaLembrete.id} ('${tarefaParaLembrete.descricao}') não agendado pois a hora do lembrete (${dataFormatadaParaLog(tarefaParaLembrete.lembreteDateTime!!)}) já passou.")
+                    withContext(Dispatchers.Main) {
+                        Toast.makeText(this@TarefasActivity, "Hora do lembrete para '${tarefaParaLembrete.descricao}' já passou. Lembrete não agendado.", Toast.LENGTH_LONG).show()
+                    }
+                }
+            } else {
+                Log.d("TarefasActivity_Lembrete", "Lembrete NÃO configurado para Tarefa ID: ${tarefaParaLembrete.id} ('${tarefaParaLembrete.descricao}').")
+                // IMPLEMENTAÇÃO REAL (futuro): Cancelar alarme se existia antes...
+            }
+
+
+            withContext(Dispatchers.Main) {
+                // Toast de "Tarefa Salva!" já está aqui, pode ser redundante se o Toast do lembrete for mostrado.
+                // Decidir qual Toast manter ou se ambos são ok. Por ora, manterei ambos.
+                Toast.makeText(this@TarefasActivity, "Tarefa salva!", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    // Função helper para log
+    private fun dataFormatadaParaLog(timestamp: Long): String {
+        return SimpleDateFormat("dd/MM/yyyy HH:mm:ss", Locale.getDefault()).format(Date(timestamp))
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        onBackPressedDispatcher.onBackPressed()
+        return true
+    }
+}

--- a/app/src/main/java/com/agendafocopei/ui/adapter/TarefaAdapter.kt
+++ b/app/src/main/java/com/agendafocopei/ui/adapter/TarefaAdapter.kt
@@ -1,0 +1,138 @@
+package com.agendafocopei.ui.adapter
+
+import android.content.Context
+import android.content.res.ColorStateList
+import android.graphics.Color
+import android.graphics.Paint
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.content.ContextCompat
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.agendafocopei.R
+import com.agendafocopei.data.Tarefa // Import da entidade Tarefa, não TarefaDisplay diretamente aqui
+import com.agendafocopei.databinding.ListItemTarefaBinding
+import com.agendafocopei.ui.model.TarefaDisplay // Import do modelo de display
+import java.text.SimpleDateFormat
+import java.util.*
+
+class TarefaAdapter(
+    private val onTarefaCheckChanged: (TarefaDisplay, Boolean) -> Unit,
+    private val onEditClickListener: (TarefaDisplay) -> Unit
+    // Adicionar onItemClickListener se necessário no futuro
+) : ListAdapter<TarefaDisplay, TarefaAdapter.TarefaViewHolder>(TarefaDiffCallback()) {
+
+    // Formatos de data movidos para dentro do ViewHolder ou para um local mais acessível se necessário fora dele.
+    // Para este adapter, eles são usados apenas no ViewHolder.
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TarefaViewHolder {
+        val binding = ListItemTarefaBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return TarefaViewHolder(binding, onTarefaCheckChanged, onEditClickListener)
+    }
+
+    override fun onBindViewHolder(holder: TarefaViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class TarefaViewHolder(
+        private val binding: ListItemTarefaBinding,
+        private val onCheckChanged: (TarefaDisplay, Boolean) -> Unit,
+        private val onEditClick: (TarefaDisplay) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        private val context: Context = itemView.context
+        private val displayPrazoFormat = SimpleDateFormat("dd/MM/yy HH:mm", Locale("pt", "BR"))
+        private val storedPrazoDataFormat = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault())
+
+        fun bind(tarefaDisplay: TarefaDisplay) {
+            val tarefa = tarefaDisplay.tarefa
+            binding.textViewTarefaDescricao.text = tarefa.descricao
+
+            binding.checkBoxTarefaConcluida.setOnCheckedChangeListener(null)
+            binding.checkBoxTarefaConcluida.isChecked = tarefa.concluida
+            binding.checkBoxTarefaConcluida.setOnCheckedChangeListener { _, isChecked ->
+                onCheckChanged(tarefaDisplay, isChecked)
+            }
+
+            if (tarefa.concluida) {
+                binding.textViewTarefaDescricao.paintFlags = binding.textViewTarefaDescricao.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG
+            } else {
+                binding.textViewTarefaDescricao.paintFlags = binding.textViewTarefaDescricao.paintFlags and Paint.STRIKE_THRU_TEXT_FLAG.inv()
+            }
+
+            when (tarefa.prioridade) {
+                0 -> binding.viewPrioridadeTarefa.setBackgroundColor(ContextCompat.getColor(context, R.color.prioridade_baixa))
+                1 -> binding.viewPrioridadeTarefa.setBackgroundColor(ContextCompat.getColor(context, R.color.prioridade_media))
+                2 -> binding.viewPrioridadeTarefa.setBackgroundColor(ContextCompat.getColor(context, R.color.prioridade_alta))
+                else -> binding.viewPrioridadeTarefa.setBackgroundColor(Color.TRANSPARENT)
+            }
+
+            if (tarefa.prazoData != null) {
+                var prazoStr = ""
+                try {
+                    val date = storedPrazoDataFormat.parse(tarefa.prazoData!!)
+                    prazoStr = SimpleDateFormat("dd/MM/yy", Locale("pt","BR")).format(date!!)
+                } catch (e: Exception) {
+                    prazoStr = tarefa.prazoData!!
+                }
+
+                if (tarefa.prazoHora != null) {
+                    prazoStr += " ${tarefa.prazoHora}"
+                }
+                binding.textViewTarefaPrazo.text = "Prazo: $prazoStr"
+                binding.textViewTarefaPrazo.visibility = View.VISIBLE
+            } else {
+                binding.textViewTarefaPrazo.visibility = View.GONE
+            }
+
+            // Chip Disciplina
+            if (tarefaDisplay.nomeDisciplina != null) {
+                binding.chipDisciplinaTarefa.text = tarefaDisplay.nomeDisciplina
+                val corChipDisciplina = tarefaDisplay.corDisciplina ?: ContextCompat.getColor(context, R.color.cor_padrao_cinza_claro)
+                binding.chipDisciplinaTarefa.chipBackgroundColor = ColorStateList.valueOf(corChipDisciplina)
+                // Verificar contraste do texto do chip
+                binding.chipDisciplinaTarefa.setTextColor(getTextColorForBackground(corChipDisciplina))
+                binding.chipDisciplinaTarefa.visibility = View.VISIBLE
+            } else {
+                binding.chipDisciplinaTarefa.visibility = View.GONE
+            }
+
+            // Chip Turma
+            if (tarefaDisplay.nomeTurma != null) {
+                binding.chipTurmaTarefa.text = tarefaDisplay.nomeTurma
+                val corChipTurma = tarefaDisplay.corTurma ?: ContextCompat.getColor(context, R.color.cor_padrao_cinza_claro)
+                binding.chipTurmaTarefa.chipBackgroundColor = ColorStateList.valueOf(corChipTurma)
+                binding.chipTurmaTarefa.setTextColor(getTextColorForBackground(corChipTurma))
+                binding.chipTurmaTarefa.visibility = View.VISIBLE
+            } else {
+                binding.chipTurmaTarefa.visibility = View.GONE
+            }
+
+            binding.chipGroupAssociacoesTarefa.visibility =
+                if(binding.chipDisciplinaTarefa.visibility == View.VISIBLE || binding.chipTurmaTarefa.visibility == View.VISIBLE) View.VISIBLE else View.GONE
+
+            binding.buttonEditarTarefaItem.setOnClickListener { onEditClick(tarefaDisplay) }
+        }
+
+        // Helper para determinar a cor do texto com base na luminância do fundo
+        private fun getTextColorForBackground(backgroundColor: Int): Int {
+            return if (androidx.core.graphics.ColorUtils.calculateLuminance(backgroundColor) > 0.6) { // Limiar pode ser ajustado
+                Color.BLACK // Fundo claro, texto escuro
+            } else {
+                Color.WHITE // Fundo escuro, texto claro
+            }
+        }
+    }
+
+    class TarefaDiffCallback : DiffUtil.ItemCallback<TarefaDisplay>() {
+        override fun areItemsTheSame(oldItem: TarefaDisplay, newItem: TarefaDisplay): Boolean {
+            return oldItem.tarefa.id == newItem.tarefa.id
+        }
+
+        override fun areContentsTheSame(oldItem: TarefaDisplay, newItem: TarefaDisplay): Boolean {
+            return oldItem == newItem
+        }
+    }
+}

--- a/app/src/main/java/com/agendafocopei/ui/dialog/FormularioAnotacaoFragment.kt
+++ b/app/src/main/java/com/agendafocopei/ui/dialog/FormularioAnotacaoFragment.kt
@@ -1,0 +1,277 @@
+package com.agendafocopei.ui.dialog
+
+import android.Manifest
+import android.app.Activity
+import android.app.DatePickerDialog
+import android.app.TimePickerDialog
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.os.Bundle
+import android.speech.RecognizerIntent
+import android.speech.SpeechRecognizer
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.DialogFragment
+import androidx.lifecycle.lifecycleScope
+import com.agendafocopei.R
+import com.agendafocopei.data.Anotacao
+import com.agendafocopei.data.AnotacaoDao
+import com.agendafocopei.data.AppDatabase
+import com.agendafocopei.data.Turma
+import com.agendafocopei.data.TurmaDao
+import com.agendafocopei.databinding.DialogFormularioAnotacaoBinding
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.text.ParseException
+import java.text.SimpleDateFormat
+import java.util.*
+
+class FormularioAnotacaoFragment : DialogFragment(), ColorPickerDialogFragment.ColorPickerListener {
+
+    private var _binding: DialogFormularioAnotacaoBinding? = null
+    private val binding get() = _binding!!
+
+    interface FormularioAnotacaoListener {
+        fun onAnotacaoSalva(anotacao: Anotacao)
+    }
+
+    private var listener: FormularioAnotacaoListener? = null
+    private var anotacaoIdParaEdicao: Int? = null
+    private var anotacaoParaEdicao: Anotacao? = null
+
+    private lateinit var anotacaoDao: AnotacaoDao
+    private lateinit var turmaDao: TurmaDao
+
+    private var listaTurmas: List<Turma> = emptyList()
+    private var corSelecionadaAnotacao: Int? = null
+
+    private lateinit var requestAudioPermissionLauncher: ActivityResultLauncher<String>
+    private lateinit var speechRecognizerLauncher: ActivityResultLauncher<Intent>
+
+
+    companion object {
+        const val TAG = "FormularioAnotacaoDialog"
+        private const val ARG_ANOTACAO_ID = "arg_anotacao_id"
+        private const val COLOR_PICKER_REQUEST_TAG = "anotacao_color_picker"
+
+        fun newInstance(anotacaoId: Int? = null): FormularioAnotacaoFragment {
+            val fragment = FormularioAnotacaoFragment()
+            val args = Bundle()
+            anotacaoId?.let { args.putInt(ARG_ANOTACAO_ID, it) }
+            fragment.arguments = args
+            return fragment
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            if (it.containsKey(ARG_ANOTACAO_ID)) {
+                anotacaoIdParaEdicao = it.getInt(ARG_ANOTACAO_ID)
+            }
+        }
+        val db = AppDatabase.getDatabase(requireContext())
+        anotacaoDao = db.anotacaoDao()
+        turmaDao = db.turmaDao()
+
+        // Inicializar launchers
+        requestAudioPermissionLauncher = registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
+            if (isGranted) {
+                iniciarReconhecimentoDeVoz()
+            } else {
+                Toast.makeText(requireContext(), "Permissão de áudio negada.", Toast.LENGTH_SHORT).show()
+            }
+        }
+
+        speechRecognizerLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            if (result.resultCode == Activity.RESULT_OK && result.data != null) {
+                val speechResults = result.data?.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS)
+                if (!speechResults.isNullOrEmpty()) {
+                    val textoReconhecido = speechResults[0]
+                    val textoAtual = binding.editTextConteudoAnotacao.text.toString()
+                    binding.editTextConteudoAnotacao.setText(if (textoAtual.isNotEmpty()) "$textoAtual $textoReconhecido" else textoReconhecido)
+                }
+            } else {
+                 Toast.makeText(requireContext(), "Falha no reconhecimento de voz ou cancelado.", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogFormularioAnotacaoBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupTurmaSpinner()
+        setupColorPicker()
+        setupGravarVozButton()
+
+        if (anotacaoIdParaEdicao != null) {
+            binding.textViewFormularioAnotacaoTitulo.text = "Editar Anotação"
+            carregarAnotacaoParaEdicao(anotacaoIdParaEdicao!!)
+        } else {
+            binding.textViewFormularioAnotacaoTitulo.text = "Nova Anotação"
+            updateColorPreview()
+        }
+
+        binding.buttonSalvarAnotacao.setOnClickListener { salvarAnotacao() }
+        binding.buttonCancelarAnotacao.setOnClickListener { dismiss() }
+    }
+
+    private fun setupTurmaSpinner() {
+        lifecycleScope.launch {
+            listaTurmas = withContext(Dispatchers.IO) { turmaDao.buscarTodas().first() }
+            val nomesTurmasComOpcao = listOf("Nenhuma (Geral/Pessoal)") + listaTurmas.map { it.nome }
+            val turmaAdapter = ArrayAdapter(requireContext(), android.R.layout.simple_spinner_item, nomesTurmasComOpcao).apply {
+                setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
+            }
+            binding.spinnerTurmaAnotacao.adapter = turmaAdapter
+
+            if (anotacaoIdParaEdicao != null && anotacaoParaEdicao != null) {
+                selecionarValoresSpinnerEdicao(anotacaoParaEdicao!!)
+            }
+        }
+    }
+
+    private fun setupColorPicker() {
+        binding.buttonEscolherCorAnotacao.setOnClickListener {
+            val dialog = ColorPickerDialogFragment.newInstance(corSelecionadaAnotacao, COLOR_PICKER_REQUEST_TAG)
+            dialog.show(childFragmentManager, ColorPickerDialogFragment.TAG)
+        }
+        binding.viewPreviewCorAnotacao.setOnClickListener {
+             binding.buttonEscolherCorAnotacao.performClick()
+        }
+    }
+
+    private fun setupGravarVozButton() {
+        binding.buttonGravarVozAnotacao.setOnClickListener {
+            when {
+                ContextCompat.checkSelfPermission(
+                    requireContext(),
+                    Manifest.permission.RECORD_AUDIO
+                ) == PackageManager.PERMISSION_GRANTED -> {
+                    iniciarReconhecimentoDeVoz()
+                }
+                shouldShowRequestPermissionRationale(Manifest.permission.RECORD_AUDIO) -> {
+                    // Explicar ao usuário e pedir novamente (ou direcionar para configs)
+                    // Por simplicidade, pedindo direto novamente ou informando.
+                    Toast.makeText(requireContext(), "Permissão de áudio é necessária para esta funcionalidade.", Toast.LENGTH_LONG).show()
+                    requestAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO) // Tenta pedir de novo
+                }
+                else -> {
+                    requestAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                }
+            }
+        }
+    }
+
+    private fun iniciarReconhecimentoDeVoz() {
+        if (!SpeechRecognizer.isRecognitionAvailable(requireContext())) {
+            Toast.makeText(requireContext(), "Reconhecimento de voz não disponível neste dispositivo.", Toast.LENGTH_LONG).show()
+            return
+        }
+        val speechIntent = Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+            putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
+            putExtra(RecognizerIntent.EXTRA_PROMPT, "Fale agora para sua anotação...")
+            // putExtra(RecognizerIntent.EXTRA_LANGUAGE, "pt-BR") // Opcional
+        }
+        try {
+            speechRecognizerLauncher.launch(speechIntent)
+        } catch (e: ActivityNotFoundException) {
+            Toast.makeText(requireContext(), "App de reconhecimento de voz não encontrado. Considere instalar o app Google.", Toast.LENGTH_LONG).show()
+        }
+    }
+
+
+    private fun updateColorPreview() {
+        binding.viewPreviewCorAnotacao.setBackgroundColor(corSelecionadaAnotacao ?: Color.TRANSPARENT)
+    }
+
+    private fun carregarAnotacaoParaEdicao(id: Int) {
+        lifecycleScope.launch {
+            anotacaoParaEdicao = withContext(Dispatchers.IO) { anotacaoDao.buscarPorId(id) }
+            anotacaoParaEdicao?.let { anotacao ->
+                binding.editTextConteudoAnotacao.setText(anotacao.conteudo)
+                binding.editTextTagsAnotacao.setText(anotacao.tagsString)
+                corSelecionadaAnotacao = anotacao.cor
+                updateColorPreview()
+                binding.editTextAlunoAnotacao.setText(anotacao.alunoNome)
+
+                if(listaTurmas.isNotEmpty()){
+                     selecionarValoresSpinnerEdicao(anotacao)
+                }
+            }
+        }
+    }
+
+    private fun selecionarValoresSpinnerEdicao(anotacao: Anotacao) {
+        val turmaPos = anotacao.turmaId?.let { turId -> listaTurmas.indexOfFirst { it.id == turId } } ?: -1
+        binding.spinnerTurmaAnotacao.setSelection(if (turmaPos != -1) turmaPos + 1 else 0)
+    }
+
+    private fun salvarAnotacao() {
+        val conteudo = binding.editTextConteudoAnotacao.text.toString().trim()
+        if (conteudo.isEmpty()) {
+            binding.editTextConteudoAnotacao.error = "Conteúdo é obrigatório"
+            return
+        } else {
+            binding.editTextConteudoAnotacao.error = null
+        }
+
+        val tags = binding.editTextTagsAnotacao.text.toString().trim()
+        val alunoNome = binding.editTextAlunoAnotacao.text.toString().trim()
+
+        val turmaIdSelecionada: Int? = if (binding.spinnerTurmaAnotacao.selectedItemPosition > 0 && listaTurmas.isNotEmpty()) {
+            listaTurmas[binding.spinnerTurmaAnotacao.selectedItemPosition - 1].id
+        } else null
+
+        val anotacaoParaSalvar = Anotacao(
+            id = anotacaoIdParaEdicao ?: 0,
+            conteudo = conteudo,
+            dataCriacao = anotacaoParaEdicao?.dataCriacao ?: System.currentTimeMillis(),
+            dataModificacao = System.currentTimeMillis(),
+            cor = corSelecionadaAnotacao,
+            turmaId = turmaIdSelecionada,
+            alunoNome = alunoNome.ifEmpty { null },
+            tagsString = tags.ifEmpty { null }
+        )
+
+        listener?.onAnotacaoSalva(anotacaoParaSalvar)
+        dismiss()
+    }
+
+    override fun onColorSelected(color: Int, tag: String?) {
+        if (tag == COLOR_PICKER_REQUEST_TAG) {
+            corSelecionadaAnotacao = color
+            updateColorPreview()
+        }
+    }
+
+    fun setListener(listener: FormularioAnotacaoListener) {
+        this.listener = listener
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/agendafocopei/ui/pomodoro/ConfigPomodoroDialogFragment.kt
+++ b/app/src/main/java/com/agendafocopei/ui/pomodoro/ConfigPomodoroDialogFragment.kt
@@ -1,0 +1,113 @@
+package com.agendafocopei.ui.pomodoro
+
+import android.content.Context
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.DialogFragment
+import com.agendafocopei.databinding.DialogConfigPomodoroBinding
+// Importar as chaves do ViewModel para consistência
+// import com.agendafocopei.ui.pomodoro.PomodoroViewModel.Companion.PREFS_NAME // etc.
+
+class ConfigPomodoroDialogFragment : DialogFragment() {
+
+    private var _binding: DialogConfigPomodoroBinding? = null
+    private val binding get() = _binding!!
+
+    interface ConfigPomodoroListener {
+        fun onConfigSalva(focoMin: Int, curtaMin: Int, longaMin: Int, ciclos: Int, hiperfoco: Boolean, som: Boolean)
+    }
+
+    private var listener: ConfigPomodoroListener? = null
+    private lateinit var prefs: SharedPreferences
+
+    // Usar as mesmas chaves definidas no PomodoroViewModel
+    companion object {
+        const val TAG = "ConfigPomodoroDialog"
+        // SharedPreferences Keys (replicadas aqui para uso, idealmente de um local comum ou do ViewModel)
+        private const val PREFS_NAME_INTERNAL = "pomodoro_prefs" // Evitar conflito com companion do ViewModel se importado diretamente
+        private const val KEY_FOCO_MIN_INTERNAL = "foco_min"
+        private const val KEY_PAUSA_CURTA_MIN_INTERNAL = "pausa_curta_min"
+        private const val KEY_PAUSA_LONGA_MIN_INTERNAL = "pausa_longa_min"
+        private const val KEY_CICLOS_ATE_PAUSA_LONGA_INTERNAL = "ciclos_pausa_longa"
+        private const val KEY_MODO_HIPERFOCO_INTERNAL = "modo_hiperfoco"
+        private const val KEY_ALARME_SONORO_INTERNAL = "alarme_sonoro"
+
+        fun newInstance(): ConfigPomodoroDialogFragment {
+            return ConfigPomodoroDialogFragment()
+        }
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context)
+        listener = parentFragment as? ConfigPomodoroListener ?: activity as? ConfigPomodoroListener
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = DialogConfigPomodoroBinding.inflate(inflater, container, false)
+        prefs = requireActivity().getSharedPreferences(PREFS_NAME_INTERNAL, Context.MODE_PRIVATE)
+        return binding.root
+    }
+
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        dialog?.setTitle("Configurações do Pomodoro")
+        carregarConfiguracoes()
+
+        binding.buttonSalvarConfigPomodoro.setOnClickListener {
+            salvarEFechar()
+        }
+        binding.buttonCancelarConfigPomodoro.setOnClickListener {
+            dismiss()
+        }
+    }
+
+    private fun carregarConfiguracoes() {
+        binding.editTextTempoFocoConfig.setText(prefs.getInt(KEY_FOCO_MIN_INTERNAL, 25).toString())
+        binding.editTextPausaCurtaConfig.setText(prefs.getInt(KEY_PAUSA_CURTA_MIN_INTERNAL, 5).toString())
+        binding.editTextPausaLongaConfig.setText(prefs.getInt(KEY_PAUSA_LONGA_MIN_INTERNAL, 15).toString())
+        binding.editTextCiclosPausaLongaConfig.setText(prefs.getInt(KEY_CICLOS_ATE_PAUSA_LONGA_INTERNAL, 4).toString())
+        binding.switchModoHiperfocoConfig.isChecked = prefs.getBoolean(KEY_MODO_HIPERFOCO_INTERNAL, false)
+        binding.switchAlarmeSonoroConfig.isChecked = prefs.getBoolean(KEY_ALARME_SONORO_INTERNAL, true)
+    }
+
+    private fun salvarEFechar() {
+        val focoMin = binding.editTextTempoFocoConfig.text.toString().toIntOrNull() ?: 25
+        val pausaCurtaMin = binding.editTextPausaCurtaConfig.text.toString().toIntOrNull() ?: 5
+        val pausaLongaMin = binding.editTextPausaLongaConfig.text.toString().toIntOrNull() ?: 15
+        val ciclos = binding.editTextCiclosPausaLongaConfig.text.toString().toIntOrNull() ?: 4
+        val hiperfoco = binding.switchModoHiperfocoConfig.isChecked
+        val som = binding.switchAlarmeSonoroConfig.isChecked
+
+        if (focoMin <= 0 || pausaCurtaMin < 0 || pausaLongaMin < 0 || ciclos <= 0) { // Pausas podem ser 0 para hiperfoco extremo
+            Toast.makeText(context, "Valores de tempo e ciclo devem ser positivos.", Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        prefs.edit().apply {
+            putInt(KEY_FOCO_MIN_INTERNAL, focoMin)
+            putInt(KEY_PAUSA_CURTA_MIN_INTERNAL, pausaCurtaMin)
+            putInt(KEY_PAUSA_LONGA_MIN_INTERNAL, pausaLongaMin)
+            putInt(KEY_CICLOS_ATE_PAUSA_LONGA_INTERNAL, ciclos)
+            putBoolean(KEY_MODO_HIPERFOCO_INTERNAL, hiperfoco)
+            putBoolean(KEY_ALARME_SONORO_INTERNAL, som)
+            apply()
+        }
+
+        listener?.onConfigSalva(focoMin, pausaCurtaMin, pausaLongaMin, ciclos, hiperfoco, som)
+        dismiss()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/test/java/com/agendafocopei/ui/pomodoro/PomodoroViewModelTest.kt
+++ b/app/src/test/java/com/agendafocopei/ui/pomodoro/PomodoroViewModelTest.kt
@@ -1,0 +1,257 @@
+package com.agendafocopei.ui.pomodoro
+
+import android.content.Context
+import android.content.SharedPreferences
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.ArgumentCaptor
+import org.mockito.Captor
+import org.mockito.Mock
+import org.mockito.Mockito.*
+import org.mockito.junit.MockitoJUnitRunner
+import java.util.concurrent.TimeUnit
+import org.junit.Assert.*
+
+@RunWith(MockitoJUnitRunner::class)
+class PomodoroViewModelTest {
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Mock
+    private lateinit var mockContext: Context // Mock Context para SharedPreferences e DND (embora DND não testado aqui)
+
+    @Mock
+    private lateinit var mockSharedPreferences: SharedPreferences
+
+    @Mock
+    private lateinit var mockEditor: SharedPreferences.Editor
+
+    private lateinit var viewModel: PomodoroViewModel
+
+    // Captors para verificar interações com LiveData
+    @Captor
+    private lateinit var longCaptor: ArgumentCaptor<Long>
+
+    @Captor
+    private lateinit var stateCaptor: ArgumentCaptor<PomodoroState>
+
+    @Captor
+    private lateinit var intCaptor: ArgumentCaptor<Int>
+
+    @Before
+    fun setUp() {
+        // Configuração padrão do mock SharedPreferences
+        `when`(mockContext.getSharedPreferences(PomodoroViewModel.PREFS_NAME, Context.MODE_PRIVATE)).thenReturn(mockSharedPreferences)
+        `when`(mockSharedPreferences.edit()).thenReturn(mockEditor)
+        `when`(mockEditor.putInt(anyString(), anyInt())).thenReturn(mockEditor)
+        `when`(mockEditor.putLong(anyString(), anyLong())).thenReturn(mockEditor)
+        `when`(mockEditor.putBoolean(anyString(), anyBoolean())).thenReturn(mockEditor)
+
+        // Configurar valores padrão para carregamento inicial
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_FOCO_MIN, 25)).thenReturn(25)
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_PAUSA_CURTA_MIN, 5)).thenReturn(5)
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_PAUSA_LONGA_MIN, 15)).thenReturn(15)
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_CICLOS_ATE_PAUSA_LONGA, 4)).thenReturn(4)
+        `when`(mockSharedPreferences.getBoolean(PomodoroViewModel.KEY_MODO_HIPERFOCO, false)).thenReturn(false)
+        `when`(mockSharedPreferences.getBoolean(PomodoroViewModel.KEY_ALARME_SONORO, true)).thenReturn(true)
+
+        viewModel = PomodoroViewModel()
+        viewModel.inicializarComPrefs(mockContext, mockSharedPreferences) // Inicializa com mocks
+    }
+
+    @Test
+    fun `estadoInicial_deveSerProntoETempoDeFocoPadrao`() {
+        assertEquals(PomodoroState.PRONTO, viewModel.estadoAtual.value)
+        assertEquals(TimeUnit.MINUTES.toMillis(25), viewModel.tempoRestanteMillis.value)
+        assertEquals(0, viewModel.cicloFocoAtual.value) // 0 indica pronto para o primeiro ciclo
+        assertEquals(TimeUnit.MINUTES.toMillis(25), viewModel.tempoTotalCicloAtualMillis.value)
+    }
+
+    @Test
+    fun `setConfiguracoes_atualizaDimensoesCorretamenteEChamaReset`() {
+        viewModel.setConfiguracoes(focoMin = 30, curtaMin = 6, longaMin = 20, ciclos = 3, hiperfoco = true, som = false)
+        // setConfiguracoes chama resetarParaEstadoInicial, que atualiza os LiveData
+        assertEquals(PomodoroState.PRONTO, viewModel.estadoAtual.value)
+        assertEquals(TimeUnit.MINUTES.toMillis(30), viewModel.tempoRestanteMillis.value)
+        assertEquals(TimeUnit.MINUTES.toMillis(30), viewModel.duracaoFocoMillis.value) // Verifica se a config foi atualizada
+        assertEquals(true, viewModel.ativarModoHiperfoco.value)
+        assertEquals(false, viewModel.ativarAlarmeSonoro.value)
+    }
+
+    @Test
+    fun `carregarConfiguracoes_carregaValoresDoSharedPreferencesCorretamente`() {
+        // Simula diferentes valores nas prefs antes de inicializar
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_FOCO_MIN, 25)).thenReturn(20)
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_PAUSA_CURTA_MIN, 5)).thenReturn(4)
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_PAUSA_LONGA_MIN, 15)).thenReturn(10)
+        `when`(mockSharedPreferences.getInt(PomodoroViewModel.KEY_CICLOS_ATE_PAUSA_LONGA, 4)).thenReturn(2)
+        `when`(mockSharedPreferences.getBoolean(PomodoroViewModel.KEY_MODO_HIPERFOCO, false)).thenReturn(true)
+        `when`(mockSharedPreferences.getBoolean(PomodoroViewModel.KEY_ALARME_SONORO, true)).thenReturn(false)
+
+        viewModel.inicializarComPrefs(mockContext, mockSharedPreferences) // Re-inicializa para carregar novos mocks
+
+        assertEquals(TimeUnit.MINUTES.toMillis(20), viewModel.duracaoFocoMillis.value)
+        assertEquals(TimeUnit.MINUTES.toMillis(4), viewModel.duracaoPausaCurtaMillis.value)
+        assertEquals(TimeUnit.MINUTES.toMillis(10), viewModel.duracaoPausaLongaMillis.value)
+        assertEquals(2, viewModel.ciclosAtePausaLonga.value)
+        assertEquals(true, viewModel.ativarModoHiperfoco.value)
+        assertEquals(false, viewModel.ativarAlarmeSonoro.value)
+    }
+
+    @Test
+    fun `salvarConfiguracoes_salvaValoresCorretosNoSharedPreferences`() {
+        viewModel.setConfiguracoes(focoMin = 50, curtaMin = 10, longaMin = 25, ciclos = 2, hiperfoco = true, som = false)
+
+        verify(mockEditor).putInt(PomodoroViewModel.KEY_FOCO_MIN, 50)
+        verify(mockEditor).putInt(PomodoroViewModel.KEY_PAUSA_CURTA_MIN, 10)
+        verify(mockEditor).putInt(PomodoroViewModel.KEY_PAUSA_LONGA_MIN, 25)
+        verify(mockEditor).putInt(PomodoroViewModel.KEY_CICLOS_ATE_PAUSA_LONGA, 2)
+        verify(mockEditor).putBoolean(PomodoroViewModel.KEY_MODO_HIPERFOCO, true)
+        verify(mockEditor).putBoolean(PomodoroViewModel.KEY_ALARME_SONORO, false)
+        verify(mockEditor, times(2)).apply() // Uma vez em setConfiguracoes (para bools) e outra em salvarConfiguracoes (para ints)
+    }
+
+
+    @Test
+    fun `iniciarPausar_quandoPronto_vaiParaFoco`() {
+        viewModel.iniciarPausar(mockContext)
+        assertEquals(PomodoroState.FOCO, viewModel.estadoAtual.value)
+        assertEquals(1, viewModel.cicloFocoAtual.value)
+        // Testar se o timer iniciou é mais complexo, mas podemos verificar o tempo inicial
+        assertEquals(viewModel.duracaoFocoMillis.value, viewModel.tempoRestanteMillis.value)
+    }
+
+    @Test
+    fun `iniciarPausar_quandoFoco_vaiParaPausado`() {
+        viewModel.iniciarPausar(mockContext) // Para FOCO
+        // Simular passagem de tempo (não trivial sem Robolectric ou TestCoroutineDispatcher)
+        // Para este teste, vamos assumir que o timer estava rodando e o tempo diminuiu um pouco
+        // viewModel._tempoRestanteMillis.value = viewModel.duracaoFocoMillis.value!! - 1000 // Simulação manual para teste
+
+        viewModel.iniciarPausar(mockContext) // Para PAUSADO
+        assertEquals(PomodoroState.PAUSADO, viewModel.estadoAtual.value)
+        // assertTrue(viewModel.millisRestantesAoPausar > 0) // Não podemos garantir sem controle do timer
+    }
+
+    @Test
+    fun `iniciarPausar_quandoPausadoEmFoco_retomaParaFoco`() {
+        viewModel.iniciarPausar(mockContext) // PRONTO -> FOCO
+        // Simular que o timer rodou um pouco antes de pausar
+        // viewModel._tempoRestanteMillis.value = (viewModel.duracaoFocoMillis.value ?: 0) - 5000L
+        // viewModel.millisRestantesAoPausar = viewModel._tempoRestanteMillis.value ?: 0L
+        // viewModel.estadoAntesDePausar = PomodoroState.FOCO
+        // viewModel._estadoAtual.value = PomodoroState.PAUSADO
+        // A forma acima é manipulação interna, o ideal é chamar o método que pausa:
+        viewModel.iniciarPausar(mockContext) // FOCO -> PAUSADO (estadoAntesDePausar = FOCO)
+
+        viewModel.iniciarPausar(mockContext) // PAUSADO -> FOCO (retoma)
+        assertEquals(PomodoroState.FOCO, viewModel.estadoAtual.value)
+    }
+
+    // Testes para avancarParaProximoEstado são mais complexos pois dependem do onFinish do timer.
+    // Vamos testar a lógica de pularParaProximoCiclo que chama avancarParaProximoEstado diretamente.
+
+    @Test
+    fun `pularParaProximoCiclo_deFocoAposMenosDeNCiclos_vaiParaPausaCurta`() {
+        viewModel.setConfiguracoes(25, 5, 15, 4, false, true) // 4 ciclos para longa
+        viewModel.iniciarPausar(mockContext) // Inicia FOCO (ciclo 1)
+        assertEquals(PomodoroState.FOCO, viewModel.estadoAtual.value)
+        assertEquals(1, viewModel.cicloFocoAtual.value)
+
+        viewModel.pularParaProximoCiclo(mockContext) // Simula fim do FOCO 1
+        assertEquals(PomodoroState.PAUSA_CURTA, viewModel.estadoAtual.value)
+        assertEquals(TimeUnit.MINUTES.toMillis(5), viewModel.tempoRestanteMillis.value)
+        // cicloFocoAtual ainda é 1, pois a pausa pertence ao ciclo de foco
+    }
+
+    @Test
+    fun `pularParaProximoCiclo_dePausaCurta_vaiParaFocoEIncrementaCiclo`() {
+        viewModel.setConfiguracoes(25, 5, 15, 4, false, true)
+        viewModel.iniciarPausar(mockContext) // FOCO 1
+        viewModel.pularParaProximoCiclo(mockContext) // PAUSA_CURTA 1
+        assertEquals(PomodoroState.PAUSA_CURTA, viewModel.estadoAtual.value)
+        assertEquals(1, viewModel.cicloFocoAtual.value)
+
+
+        viewModel.pularParaProximoCiclo(mockContext) // Simula fim da PAUSA_CURTA 1
+        assertEquals(PomodoroState.FOCO, viewModel.estadoAtual.value)
+        assertEquals(2, viewModel.cicloFocoAtual.value) // Próximo ciclo de foco
+        assertEquals(TimeUnit.MINUTES.toMillis(25), viewModel.tempoRestanteMillis.value)
+    }
+
+    @Test
+    fun `pularParaProximoCiclo_deFocoAposNCiclos_vaiParaPausaLonga`() {
+        viewModel.setConfiguracoes(1, 1, 3, 2, false, true) // Foco=1, Curta=1, Longa=3, Ciclos=2
+
+        // Ciclo 1
+        viewModel.iniciarPausar(mockContext) // Foco 1
+        viewModel.pularParaProximoCiclo(mockContext) // Pausa Curta 1
+
+        // Ciclo 2
+        viewModel.pularParaProximoCiclo(mockContext) // Foco 2
+        assertEquals(PomodoroState.FOCO, viewModel.estadoAtual.value)
+        assertEquals(2, viewModel.cicloFocoAtual.value)
+
+        viewModel.pularParaProximoCiclo(mockContext) // Fim do Foco 2 (atingiu _ciclosAtePausaLonga)
+        assertEquals(PomodoroState.PAUSA_LONGA, viewModel.estadoAtual.value)
+        assertEquals(TimeUnit.MINUTES.toMillis(3), viewModel.tempoRestanteMillis.value)
+        // cicloFocoAtual ainda é 2, pois a pausa longa pertence a este ciclo "maior"
+    }
+
+    @Test
+    fun `pularParaProximoCiclo_dePausaLonga_vaiParaFocoEResetaCicloParaUm`() {
+        viewModel.setConfiguracoes(1, 1, 3, 2, false, true)
+        // Leva até a pausa longa
+        viewModel.iniciarPausar(mockContext) // F1
+        viewModel.pularParaProximoCiclo(mockContext) // PC1
+        viewModel.pularParaProximoCiclo(mockContext) // F2
+        viewModel.pularParaProximoCiclo(mockContext) // PL (após F2)
+        assertEquals(PomodoroState.PAUSA_LONGA, viewModel.estadoAtual.value)
+        assertEquals(2, viewModel.cicloFocoAtual.value)
+
+
+        viewModel.pularParaProximoCiclo(mockContext) // Fim da Pausa Longa
+        assertEquals(PomodoroState.FOCO, viewModel.estadoAtual.value)
+        assertEquals(1, viewModel.cicloFocoAtual.value) // Ciclo de foco resetado para 1
+        assertEquals(TimeUnit.MINUTES.toMillis(1), viewModel.tempoRestanteMillis.value)
+    }
+
+
+    @Test
+    fun `resetarCicloAtualOuPomodoro_quandoEmFoco_reiniciaTempoDeFoco`() {
+        viewModel.iniciarPausar(mockContext) // Para FOCO
+        // Simular passagem de tempo (não testaremos o tick exato aqui)
+        // viewModel._tempoRestanteMillis.value = (viewModel.duracaoFocoMillis.value ?: 0) - 10000L
+
+        viewModel.resetarCicloAtualOuPomodoro(mockContext)
+        assertEquals(PomodoroState.FOCO, viewModel.estadoAtual.value)
+        assertEquals(viewModel.duracaoFocoMillis.value, viewModel.tempoRestanteMillis.value)
+        assertEquals(1, viewModel.cicloFocoAtual.value) // Mantém o ciclo atual
+    }
+
+    @Test
+    fun `resetarCicloAtualOuPomodoro_quandoPronto_permanecePronto`() {
+        viewModel.resetarCicloAtualOuPomodoro(mockContext)
+        assertEquals(PomodoroState.PRONTO, viewModel.estadoAtual.value)
+        assertEquals(viewModel.duracaoFocoMillis.value, viewModel.tempoRestanteMillis.value)
+        assertEquals(0, viewModel.cicloFocoAtual.value)
+    }
+
+    @Test
+    fun `resetarCicloAtualOuPomodoro_quandoPausado_vaiParaPronto`() {
+        viewModel.iniciarPausar(mockContext) // FOCO
+        viewModel.iniciarPausar(mockContext) // PAUSADO
+        assertEquals(PomodoroState.PAUSADO, viewModel.estadoAtual.value)
+
+        viewModel.resetarCicloAtualOuPomodoro(mockContext)
+        assertEquals(PomodoroState.PRONTO, viewModel.estadoAtual.value) // Comportamento atual: reset total se pausado
+        assertEquals(viewModel.duracaoFocoMillis.value, viewModel.tempoRestanteMillis.value)
+        assertEquals(0, viewModel.cicloFocoAtual.value)
+    }
+
+}


### PR DESCRIPTION
Este commit introduz o suporte completo ao tema escuro no aplicativo, permitindo que a interface se adapte automaticamente às suas configurações de tema claro ou escuro do sistema operacional.

Alterações principais:
- Configuração do tema principal do aplicativo para herdar de `Theme.MaterialComponents.DayNight`.
- Criação de `res/values-night/colors.xml` com uma paleta de cores otimizada para o modo escuro, seguindo as diretrizes do Material Design para contraste e legibilidade.
- Atualização de `res/values/themes.xml` e criação de `res/values-night/themes.xml` para referenciar consistentemente as cores definidas para cada modo.
- Revisão de todos os layouts e estilos para substituir cores hardcoded por referências a atributos de tema (ex: `?attr/colorSurface`, `?android:attr/textColorPrimary`) ou cores definidas para DayNight.
- Adaptação de cores customizadas geradas programaticamente:
    - Cores de prioridade de tarefas agora usam definições de `colors.xml` que variam entre modo claro e escuro.
    - Cores selecionadas por você (para disciplinas, turmas, eventos, anotações) são aplicadas a indicadores laterais, mantendo o texto principal sobre fundos de superfície do tema para garantir legibilidade.
    - `Chip`s que usam cores selecionadas por você agora ajustam dinamicamente a cor do texto (preto/branco) com base na luminância da cor de fundo do chip.
    - O card de "Próximo Compromisso" no Dashboard foi modificado para usar um indicador de cor lateral em vez de colorir todo o fundo do card, melhorando a consistência e legibilidade do texto.
- Correção da lógica de cores de texto no `MesFragment` (calendário Kizitonwose) para usar atributos de tema, garantindo a correta adaptação.

Com estas mudanças, o aplicativo agora oferece uma experiência visual consistente e confortável tanto no tema claro quanto no escuro, atendendo ao requisito RNF-01.3.