### PR TITLE
Fix: Correct parentActivityName paths in AndroidManifest.xml

### DIFF
--- a/AgendaFocoPEI/app/src/main/AndroidManifest.xml
+++ b/AgendaFocoPEI/app/src/main/AndroidManifest.xml
@@ -53,7 +53,7 @@
         <activity
             android:name=".ui.activity.AgendaActivity"
             android:label="Agenda"
-            android:parentActivityName=".DashboardActivity" />
+            android:parentActivityName=".ui.activity.DashboardActivity" />
         <activity
             android:name=".ui.activity.PlanosDeAulaGeralActivity"
             android:label="Planos de Aula"
@@ -77,7 +77,7 @@
         <activity
             android:name=".ui.activity.PomodoroActivity"
             android:label="Pomodoro"
-            android:parentActivityName=".DashboardActivity" />
+            android:parentActivityName=".ui.activity.DashboardActivity" />
         <activity
             android:name=".ui.activity.AnotacoesActivity"
             android:label="Minhas Anotações"


### PR DESCRIPTION
Corrected the android:parentActivityName attributes for AgendaActivity and PomodoroActivity to accurately reflect the location of DashboardActivity within the .ui.activity subpackage.

This resolves potential navigation issues and ensures the manifest correctly defines activity relationships.